### PR TITLE
feat: add exchange tests and ability to query sent, received, and del…

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -107,6 +107,10 @@ export class Connection extends EventEmitter {
 
   // TODO use bignumbers for byte offsets
   protected remoteMaxOffset: number
+  protected _totalReceived: BigNumber
+  protected _totalSent: BigNumber
+  protected _totalDelivered: BigNumber
+  protected _lastPacketExchangeRate: BigNumber
 
   constructor (opts: FullConnectionOpts) {
     super()
@@ -139,6 +143,11 @@ export class Connection extends EventEmitter {
     this.remoteMaxStreamId = DEFAULT_MAX_REMOTE_STREAMS
 
     this.remoteMaxOffset = MAX_DATA_SIZE * 2 // 64kb
+
+    this._totalReceived = new BigNumber(0)
+    this._totalSent = new BigNumber(0)
+    this._totalDelivered = new BigNumber(0)
+    this._lastPacketExchangeRate = new BigNumber(0)
   }
 
   /**
@@ -248,6 +257,46 @@ export class Connection extends EventEmitter {
     // TODO notify when the stream is closed
 
     return stream
+  }
+
+  /**
+   * Connections minimum exchange rate with slippage included, if not set '0' is returned.
+   */
+  get minimumAcceptableExchangeRate (): string {
+    if (this.exchangeRate) {
+      const minimumExchangeWithSlippage = this.exchangeRate
+         .times(new BigNumber(1).minus(this.slippage))
+      return minimumExchangeWithSlippage.toString()
+    }
+    return '0'
+  }
+  
+ /**
+  * Calculates the last exchange rate based on last packet successfully sent.
+  */
+  get lastPacketExchangeRate (): string {
+    return this._lastPacketExchangeRate.toString()
+  }
+
+  /**
+   * Total delivered so far, denominated in the connection plugin's units.
+   */
+  get totalDelivered (): string {
+    return this._totalDelivered.toString()
+  }
+
+  /**
+   * Total sent so far, denominated in the connection plugin's units.
+   */
+  get totalSent (): string {
+    return this._totalSent.toString()
+  }
+
+  /**
+   * Total received so far, denominated in the connection plugin's units.
+   */
+  get totalReceived (): string {
+    return this._totalReceived.toString()
   }
 
   /**
@@ -394,6 +443,7 @@ export class Connection extends EventEmitter {
 
     // Return fulfillment and response packet
     const responsePacket = new Packet(requestPacket.sequence, IlpPacketType.Fulfill, prepare.amount, responseFrames)
+    this._totalReceived = this._totalReceived.plus(responsePacket.prepareAmount)
     this.debug(`fulfilling prepare with fulfillment: ${fulfillment.toString('hex')} and response packet: ${JSON.stringify(responsePacket)}`)
     return {
       fulfillment,
@@ -836,6 +886,10 @@ export class Connection extends EventEmitter {
 
     if (responsePacket) {
       this.handleFrames(responsePacket.frames)
+      if (responsePacket.prepareAmount.isGreaterThan(0)
+        && amountToSend.isGreaterThan(0)) {
+        this._lastPacketExchangeRate = responsePacket.prepareAmount.dividedBy(amountToSend)
+      }
     }
 
     if (!responsePacket || responsePacket.ilpPacketType === IlpPacketType.Reject) {
@@ -850,6 +904,8 @@ export class Connection extends EventEmitter {
       for (let stream of streamsSentFrom) {
         stream._executeHold(requestPacket.sequence.toString())
       }
+      this._totalDelivered = this._totalDelivered.plus(responsePacket.prepareAmount)
+      this._totalSent = this._totalSent.plus(amountToSend)
 
       // If we're trying to pinpoint the Maximum Packet Amount, raise
       // the limit because we know that the testMaximumPacketAmount works
@@ -1011,7 +1067,6 @@ export class Connection extends EventEmitter {
     }
 
     this.debug(`got response to packet: ${packet.sequence}: ${JSON.stringify(responsePacket)}`)
-
     return responsePacket
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -293,7 +293,7 @@ export class Connection extends EventEmitter {
   }
 
   /**
-   * Total received so far, denominated in the connection plugin's units.
+   * Total received so far by the local side, denominated in the connection plugin's units.
    */
   get totalReceived (): string {
     return this._totalReceived.toString()
@@ -443,7 +443,7 @@ export class Connection extends EventEmitter {
 
     // Return fulfillment and response packet
     const responsePacket = new Packet(requestPacket.sequence, IlpPacketType.Fulfill, prepare.amount, responseFrames)
-    this._totalReceived = this._totalReceived.plus(responsePacket.prepareAmount)
+    this._totalReceived = this._totalReceived.plus(prepare.amount)
     this.debug(`fulfilling prepare with fulfillment: ${fulfillment.toString('hex')} and response packet: ${JSON.stringify(responsePacket)}`)
     return {
       fulfillment,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -270,7 +270,7 @@ export class Connection extends EventEmitter {
     }
     return '0'
   }
-  
+
  /**
   * Calculates the last exchange rate based on last packet successfully sent.
   */
@@ -1067,6 +1067,7 @@ export class Connection extends EventEmitter {
     }
 
     this.debug(`got response to packet: ${packet.sequence}: ${JSON.stringify(responsePacket)}`)
+
     return responsePacket
   }
 

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -193,7 +193,143 @@ describe('Connection', function () {
   })
 
   describe('Exchange Rate Handling', function () {
+    it('should modify the exchange rate until its worse than the minimum acceptable amount and the packets are rejected', async function () {
+      this.clientPlugin.maxAmount = 400
+      const exchangeRates = [0.5, 0.75, 0.25, 0.1, 0.49, 0.5, 1.25]
+      const realSendData = this.clientPlugin.sendData
+      let callCount = 0
+      const args: Buffer[] = []    
+      let rejected: Array<IlpPacket.IlpRejection> = []
+      this.clientPlugin.sendData = async (data: Buffer) => {
+        callCount++
+        args[callCount - 1] = data
+        if (callCount <= exchangeRates.length) {
+          this.clientPlugin.exchangeRate = exchangeRates[callCount - 1]
+        }
+        const response = await realSendData.call(this.clientPlugin, data)
+        if(response[0] === IlpPacket.Type.TYPE_ILP_REJECT) {
+          rejected.push(IlpPacket.deserializeIlpReject(response))
+        }
+        return response
+      }
 
+      const clientStream = this.clientConn.createStream()
+      await clientStream.sendTotal(2000)
+
+      // F99X Are Application Errors due to the exchange rate dropping below the minimum acceptable amount
+      assert.equal(rejected[0].message, 'Packet amount too large')
+      assert.equal(rejected[1].code.includes('F99'), true)
+      assert.equal(rejected[2].code.includes('F99'), true)
+      assert.equal(rejected[3].code.includes('F99'), true)
+    })
+
+    it('should set slippage and modify the exchange rate until its worse than the minimum acceptable amount - slippage and the packets are rejected', async function () {      
+      this.clientPlugin.deregisterDataHandler()
+      this.serverPlugin.deregisterDataHandler()
+
+      this.server = await createServer({ //TODO: Move to createServer
+        plugin: this.serverPlugin,
+        serverSecret: Buffer.alloc(32)
+      })
+      await this.server.listen()
+
+      const { destinationAccount, sharedSecret } = this.server.generateAddressAndSecret()
+      this.destinationAccount = destinationAccount
+      this.sharedSecret = sharedSecret
+
+      const connectionPromise = this.server.acceptConnection()
+
+      this.clientConn = await createConnection({
+        plugin: this.clientPlugin,
+        destinationAccount,
+        sharedSecret,
+        slippage: 0.05
+      })
+      this.serverConn = await connectionPromise
+      this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
+        stream.setReceiveMax(10000)
+      })
+
+      this.clientPlugin.maxAmount = 400
+      const exchangeRates = [0.5, 0.49, 0.48, 0.47, 0.5, 0.46, 0.7]
+      const realSendData = this.clientPlugin.sendData.bind(this.clientPlugin)
+      let callCount = 0
+      const args: Buffer[] = []
+      let rejected: Array<IlpPacket.IlpRejection> = []
+      this.clientPlugin.sendData = async (data: Buffer) => {
+        callCount++
+        args[callCount - 1] = data
+        if (callCount <= exchangeRates.length) {
+          this.clientPlugin.exchangeRate = exchangeRates[callCount - 1]
+        }
+        const response = await realSendData.call(this.clientPlugin, data)
+        if (response[0] === IlpPacket.Type.TYPE_ILP_REJECT) {
+          rejected.push(IlpPacket.deserializeIlpReject(response))
+        }
+        return response
+      }
+
+      const clientStream = this.clientConn.createStream()
+      await clientStream.sendTotal(2000)
+
+      // F99X Are Application Errors due to the exchange rate dropping below the minimum acceptable amount + slippage
+      assert.equal(rejected[0].message, 'Packet amount too large')
+      assert.equal(rejected[1].code.includes('F99'), true)
+      assert.equal(rejected[1].code.includes('F99'), true)
+    })
+
+    it('should check that the total received, sent, and delivered are properly calculated for the client and the server', async function () {
+      this.clientPlugin.deregisterDataHandler()
+      this.serverPlugin.deregisterDataHandler()
+
+      this.server = await createServer({
+        plugin: this.serverPlugin,
+        serverSecret: Buffer.alloc(32),
+        slippage: 0.01
+      })
+      await this.server.listen()
+
+      const { destinationAccount, sharedSecret } = this.server.generateAddressAndSecret()
+      this.destinationAccount = destinationAccount
+      this.sharedSecret = sharedSecret
+
+      const connectionPromise = this.server.acceptConnection()
+      this.clientPlugin.maxAmount = 400
+
+      this.clientConn = await createConnection({
+        plugin: this.clientPlugin,
+        destinationAccount,
+        sharedSecret,
+        slippage: 0.05
+      })
+      this.serverConn = await connectionPromise
+      this.serverConn.on('stream', async (stream: DataAndMoneyStream) => {
+        stream.setReceiveMax(10000)
+        await stream.sendTotal(111)
+      })
+
+      const clientStream = this.clientConn.createStream()
+      await clientStream.setReceiveMax(10000)
+      await clientStream.sendTotal(2000)
+
+      // Server Sends 111
+      assert.equal(this.clientConn.totalReceived, 222)
+      assert.equal(this.serverConn.totalDelivered, 222)
+      assert.equal(this.serverConn.totalSent, 111)
+
+      // Client Sends 2000
+      assert.equal(this.serverConn.totalReceived, 1000)
+      assert.equal(this.clientConn.totalDelivered, 1000)
+      assert.equal(this.clientConn.totalSent, 2000)
+
+      // Check Minimum Exchange Rates
+      assert.equal(this.serverConn.minimumAcceptableExchangeRate, 1.98)
+      assert.equal(this.clientConn.minimumAcceptableExchangeRate, 0.475)
+
+      // Check Last Packet Exchange Rate
+      assert.equal(this.serverConn.lastPacketExchangeRate, 2)
+      assert.equal(this.clientConn.lastPacketExchangeRate, 0.5)
+    })
   })
 
   describe('Maximum Packet Amount Handling', function () {


### PR DESCRIPTION
Add Exchange Rate tests for slippage and varying the exchange rate amount
Add support to query on the client and server the totalSent, totalReceived, and the totalDelivered on the connection. 

Resolves https://github.com/interledgerjs/ilp-protocol-stream/issues/8