### PR TITLE
feat: expand end & destroy test coverage, update end connection close

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -208,13 +208,17 @@ export class Connection extends EventEmitter {
   // TODO should this be sync or async?
   async end (): Promise<void> {
     this.debug('closing connection')
-    this.closed = true
 
+    let anyOpenStreams: boolean = false
     for (let [_, stream] of this.streams) {
       if (stream.isOpen()) {
+        anyOpenStreams = true
         stream.end()
         // TODO should this mark the remoteStreams as closed?
       }
+    }
+    if (!anyOpenStreams){
+      this.closed = true
     }
 
     await new Promise((resolve, reject) => {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -208,8 +208,14 @@ export class Connection extends EventEmitter {
   // TODO should this be sync or async?
   async end (): Promise<void> {
     this.debug('closing connection')
+    // Create Promises on each stream that resolve on the 'end' event so
+    // we can wait for them all to be completed before closing the connection
+    let streamEndPromises: Promise<any>[] = []
     for (let [_, stream] of this.streams) {
       if (stream.isOpen()) {
+        streamEndPromises.push(new Promise((resolve, reject) => {
+          stream.on('end', resolve)
+        }))
         stream.end()
       }
     }
@@ -221,8 +227,11 @@ export class Connection extends EventEmitter {
       /* tslint:disable-next-line:no-floating-promises */
       this.startSendLoop()
     })
-    // Wait for the send loop to finish before marking the connection as closed
-    // so the streams can finish sending data or money.
+    // Wait for the send loop to finish & all the streams to end
+    // before marking the connection as closed so the streams
+    // can finish sending data or money.
+    await Promise.all(streamEndPromises)
+
     this.closed = true
     await this.sendConnectionClose()
     this.safeEmit('end')
@@ -238,11 +247,19 @@ export class Connection extends EventEmitter {
     if (err) {
       this.safeEmit('error', err)
     }
+    // Create Promises on each stream that resolve on the 'close' event so
+    // we can wait for them all to be completed before closing the connection
+    let streamClosePromises: Promise<any>[] = []
     for (let [_, stream] of this.streams) {
+      streamClosePromises.push(new Promise((resolve, reject) => {
+        stream.on('close', resolve)
+      }))
       // TODO should we pass the error to each stream?
       stream.destroy()
     }
     await this.sendConnectionClose(err)
+    // wait for all the streams to be closed before emitting the connection 'close'
+    await Promise.all(streamClosePromises)
     this.safeEmit('close')
   }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -53,7 +53,7 @@ export class DataAndMoneyStream extends Duplex {
   protected bytesRead: number
 
   constructor (opts: StreamOpts) {
-    super()
+    super({ allowHalfOpen: false })
     this.id = opts.id
     this.isServer = opts.isServer
     this.debug = Debug(`ilp-protocol-stream:${this.isServer ? 'Server' : 'Client'}:Stream:${this.id}`)

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -53,6 +53,8 @@ export class DataAndMoneyStream extends Duplex {
   protected bytesRead: number
 
   constructor (opts: StreamOpts) {
+    // Only supporting allowHalfOpen for now so we initialize the underlying Duplex with that option set
+    // Half open support may be added in the future
     super({ allowHalfOpen: false })
     this.id = opts.id
     this.isServer = opts.isServer

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -391,6 +391,11 @@ export class DataAndMoneyStream extends Duplex {
       if (this.bytesRead === 0) {
         // Node streams only emit the 'end' event if data was actually read
         this.safeEmit('end')
+      } else {
+        // The 'end' event from the stream will not emit unless
+        // we use push null onto it. Only do this if the bytes read
+        // is not 0 since in that case when we push it will emit 'end'
+        this.push(null)
       }
       this.safeEmit('close')
       callback(err)
@@ -417,20 +422,24 @@ export class DataAndMoneyStream extends Duplex {
    */
   _destroy (error: Error | undefined | null, callback: (...args: any[]) => void): void {
     let emittedClose = false
+    let emittedEnd = false
     this.once('close', () => {
       emittedClose = true
     })
+    this.once('end', () => {
+      emittedEnd = true
+    })
+
     this.debug('destroying stream because of error:', error)
     this.closed = true
     if (error) {
       this._errorMessage = error.message
     }
-    if (this.bytesRead === 0) {
-      // Node streams only emit the 'end' event if data was actually read
-      this.safeEmit('end')
-    }
-    // Only emit the 'close' event if the stream doesn't automatically
+    // Only emit the 'close' & 'end' events if the stream doesn't automatically
     setImmediate(() => {
+      if (!emittedEnd) {
+        this.safeEmit('end')
+      }
       if (!emittedClose) {
         this.safeEmit('close')
       }

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -216,7 +216,7 @@ describe('Connection', function () {
       // TODO figure out how to check the stream record was removed..
     })
 
-    it.skip('should complete sending all data from server when end is called on server side of the connection', async function() {
+    it('should complete sending all data from server when end is called on server side of the connection', async function() {
       // TODO: Failing so skip for now
       let data: Buffer[] = []
       this.clientConn.on('stream', (stream: DataAndMoneyStream) => {
@@ -226,6 +226,7 @@ describe('Connection', function () {
       })
       const serverStream = this.serverConn.createStream()
       serverStream.write(Buffer.alloc(30000))
+      await new Promise(setImmediate)
       await this.serverConn.end()
       assert.equal(Buffer.concat(data).length, 30000)
     })
@@ -247,7 +248,7 @@ describe('Connection', function () {
       assert.callCount(moneySpy, 6)
     })
 
-    it.skip('should complete sending all data from client when end is called on client side of the connection', async function() {
+    it('should complete sending all data from client when end is called on client side of the connection', async function() {
       // TODO: Failing so skip for now
       let data: Buffer[] = []
       this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
@@ -257,6 +258,7 @@ describe('Connection', function () {
       })
       const clientStream = this.clientConn.createStream()
       clientStream.write(Buffer.alloc(30000))
+      await new Promise(setImmediate)
       await this.clientConn.end()
       assert.equal(Buffer.concat(data).length, 30000)
     })

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -336,41 +336,6 @@ describe('Connection', function () {
   })
 
   describe('destroy', function () {
-    it('should close the other side of the connection', function(done) {
-      this.clientConn.on('close', done)
-      this.serverConn.destroy()
-    })
-
-    it('should accept an error that will be emitted on the other side of the connection', function(done) {
-      const spy = sinon.spy()
-      this.clientConn.on('error', (err: Error) => {
-        assert.equal(err.message, 'Remote connection error. Code: InternalError, message: i had enough of this')
-        done()
-      })
-
-      this.serverConn.destroy(new Error('i had enough of this'))
-    })
-
-    it('should close all outgoing streams even if there is data and money still to send', function(done) {
-      const spy = sinon.spy()
-      const stream: DataAndMoneyStream = this.clientConn.createStream()
-      stream.on('close', () => {
-        spy()
-        assert.calledOnce(spy)
-        assert.equal(stream.totalSent, '0')
-        // Don't use an assert.equal here because the behavior changed between Node 8 and 10
-        assert.isAtLeast(stream.writableLength, 1)
-        assert.equal(stream.isOpen(), false)
-        done()
-      })
-      stream.setSendMax(100)
-      stream.write(Buffer.alloc(20000))
-
-      this.clientConn.destroy()
-    })
-  })
-
-  describe('destroy', function () {
     it('should close the other side of the connection', function (done) {
       this.clientConn.on('close', done)
       this.serverConn.destroy()

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -358,13 +358,13 @@ describe('DataAndMoneyStream', function () {
     it('should accept incoming money for closed streams', function (done) {
       const spy = sinon.spy()
       this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
-        stream.setReceiveMax(20000)
+        stream.setReceiveMax(1000)
         stream.end()
         stream.on('money', spy)
       })
 
       const clientStream = this.clientConn.createStream()
-      clientStream.setSendMax(20000)
+      clientStream.setSendMax(1000)
       clientStream.on('end', () => {
         assert.equal(clientStream.totalSent, '1000')
         assert.calledWith(spy, '500')

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -337,10 +337,9 @@ describe('DataAndMoneyStream', function () {
         })
       })
       const clientStream = this.clientConn.createStream()
-      await new Promise(setImmediate)
       clientStream.write(Buffer.alloc(30000))
+      clientStream.end()
       await new Promise(setImmediate)
-      await clientStream.end()
       await new Promise(setImmediate)
       await new Promise(setImmediate)
       assert.equal(Buffer.concat(data).length, 30000)
@@ -359,13 +358,13 @@ describe('DataAndMoneyStream', function () {
     it('should accept incoming money for closed streams', function (done) {
       const spy = sinon.spy()
       this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
-        stream.setReceiveMax(1000)
+        stream.setReceiveMax(20000)
         stream.end()
         stream.on('money', spy)
       })
 
       const clientStream = this.clientConn.createStream()
-      clientStream.setSendMax(1000)
+      clientStream.setSendMax(20000)
       clientStream.on('end', () => {
         assert.equal(clientStream.totalSent, '1000')
         assert.calledWith(spy, '500')

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -334,7 +334,6 @@ describe('DataAndMoneyStream', function () {
       this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
         stream.on('data', (chunk: Buffer) => {
           data.push(chunk)
-          console.log('STREAM ' + Buffer.concat(data).length)
         })
       })
       const clientStream = this.clientConn.createStream()

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -368,10 +368,45 @@ describe('DataAndMoneyStream', function () {
       })
     })
 
-    it('should not allow more data to be written once the stream is closed', async function () {
+    it('should not allow more data to be written once the stream is closed and throw an error', async function () {
       const clientStream = this.clientConn.createStream()
       clientStream.end()
       assert.throws(() => clientStream.write('hello'), 'write after end')
+    })
+
+    it('should not allow more data to be written once the stream is closed and emit an error', async function() {
+      const clientStream = this.clientConn.createStream()
+      clientStream.on('error', (err: Error) => {
+        assert.equal(err.message, 'write after end')
+      })
+      clientStream.end()
+      clientStream.write('hello')
+    })
+
+    it('should not allow more data to be written once the stream is closed and throw an error', async function() {
+      const clientStream = this.clientConn.createStream()
+      await clientStream.end()
+      assert.throws(() => clientStream.setSendMax(400), 'Stream already closed')
+    })
+
+    it('should not allow more money to be sent once the stream is closed and throw an error', async function() {
+      const clientStream = this.clientConn.createStream()
+      await clientStream.end()
+      try {
+        await clientStream.sendTotal(300)
+      } catch (err) {
+        assert.equal(err.message, 'Stream already closed')
+      }
+    })
+
+    it('should not allow more money to be sent once the stream is closed mid sending and throw an error', async function() {
+      const clientStream = this.clientConn.createStream()
+      clientStream.end()
+      try {
+        await clientStream.sendTotal(300)
+      } catch (err) {
+        assert.equal(err.message, 'Stream was closed before desired amount was sent (target: 300, totalSent: 0)')
+      }
     })
   })
 

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -329,6 +329,18 @@ describe('DataAndMoneyStream', function () {
       })
     })
 
+    it('should not close the stream until all the data has been sent', function(done) {
+      this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
+        stream.on('data', (data: Buffer) => {
+          assert.equal(data.toString(), 'hello')
+          done()
+        })
+      })
+      const clientStream = this.clientConn.createStream()
+      clientStream.write('hello')
+      clientStream.end()
+    })
+
     it('should close the stream if it could send more money but the other side is blocking it', function (done) {
       const clientStream = this.clientConn.createStream()
       clientStream.setSendMax(1000)


### PR DESCRIPTION
Expands the unit tests in #14 for:
- [ ] Make sure that end allows all the data & money to be sent from side that called end
- [ ] Make sure that destroy closed down the connection immediately from both ends and does not allow more data to be sent or received
- [ ] Calling destroy on a stream does not close the connection