### PR TITLE
Tc stream fixes

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -946,11 +946,17 @@ export class Connection extends EventEmitter {
 
         // If we're trying to pinpoint the Maximum Packet Amount, raise
         // the limit because we know that the testMaximumPacketAmount works
-        if (this.maximumPacketAmount.isFinite()
-          && amountToSend.isEqualTo(this.testMaximumPacketAmount)
-          && this.testMaximumPacketAmount.isLessThan(this.maximumPacketAmount)) {
-          const newTestMax = this.maximumPacketAmount.plus(this.testMaximumPacketAmount).dividedToIntegerBy(2)
-          this.debug(`maximum packet amount is between ${this.testMaximumPacketAmount} and ${this.maximumPacketAmount}, trying: ${newTestMax}`)
+        if (amountToSend.isEqualTo(this.testMaximumPacketAmount)
+            && this.testMaximumPacketAmount.isLessThan(this.maximumPacketAmount)) {
+          let newTestMax
+          if (this.maximumPacketAmount.isFinite()) {
+            newTestMax = this.maximumPacketAmount.plus(this.testMaximumPacketAmount).dividedToIntegerBy(2)
+            this.debug(`maximum packet amount is between ${this.testMaximumPacketAmount} and ${this.maximumPacketAmount}, trying: ${newTestMax}`)
+          } else {
+            // Increase by 2 in this case since the amount to send and text max are equal which indicates the last packet was successful
+            newTestMax = this.testMaximumPacketAmount.times(2)
+            this.debug(`last packet amount was successful, raising test max packet amount from: ${this.testMaximumPacketAmount} to: ${newTestMax}`)
+          }
           this.testMaximumPacketAmount = newTestMax
         }
 
@@ -1184,7 +1190,8 @@ export class Connection extends EventEmitter {
       // and figuring out the max amount per window. this logic is just a stand in to fix
       // infinite retries when it runs into this type of error
       const newTestAmount = BigNumber.minimum(amountSent, this.testMaximumPacketAmount).dividedToIntegerBy(2)
-      this.testMaximumPacketAmount = BigNumber.maximum(1, newTestAmount) // don't let it go to zero
+      this.testMaximumPacketAmount = BigNumber.maximum(2, newTestAmount) // don't let it go to zero, set to 2 so that the other side gets at least 1 after the exchange rate is taken into account
+      // TODO: Should we use something like 100 here so the exchange rate can always be correctly calculated?
       const delay = 100
       this.debug(`got T04: Insufficient Liquidity error. reducing the packet amount to ${this.testMaximumPacketAmount} and waiting ${delay}ms before sending another packet`)
       await new Promise((resolve, reject) => setTimeout(resolve, delay))

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -769,6 +769,8 @@ export class Connection extends EventEmitter {
           if (this.exchangeRate) {
             this.safeEmit('connect')
             this.debug('connected')
+          } else {
+            this.debug('unable to determine exchange rate')
           }
         } else {
           // TODO Send multiple packets at the same time (don't await promise)
@@ -1181,7 +1183,8 @@ export class Connection extends EventEmitter {
       // we should really be keeping track of the amount sent within a given window of time
       // and figuring out the max amount per window. this logic is just a stand in to fix
       // infinite retries when it runs into this type of error
-      this.testMaximumPacketAmount = BigNumber.minimum(amountSent, this.testMaximumPacketAmount).dividedToIntegerBy(2)
+      const newTestAmount = BigNumber.minimum(amountSent, this.testMaximumPacketAmount).dividedToIntegerBy(2)
+      this.testMaximumPacketAmount = BigNumber.maximum(1, newTestAmount) // don't let it go to zero
       const delay = 100
       this.debug(`got T04: Insufficient Liquidity error. reducing the packet amount to ${this.testMaximumPacketAmount} and waiting ${delay}ms before sending another packet`)
       await new Promise((resolve, reject) => setTimeout(resolve, delay))

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -30,6 +30,7 @@ require('source-map-support').install()
 
 const TEST_PACKET_AMOUNT = new BigNumber(1000)
 const RETRY_DELAY_START = 100
+const RETRY_DELAY_MAX = 43200000 // 12 hours should be long enough
 const MAX_DATA_SIZE = 32767
 const DEFAULT_MAX_REMOTE_STREAMS = 10
 
@@ -1186,9 +1187,9 @@ export class Connection extends EventEmitter {
       await new Promise((resolve, reject) => setTimeout(resolve, delay))
     } else if (reject.code[0] === 'T') {
       // TODO should we reduce the packet amount on other TXX errors too?
-      this.debug(`got temporary error. waiting ${this.retryDelay} before trying again`)
+      this.debug(`got temporary error. waiting ${this.retryDelay}ms before trying again`)
       const delay = this.retryDelay
-      this.retryDelay = this.retryDelay * 2
+      this.retryDelay = Math.min(this.retryDelay * 2, RETRY_DELAY_MAX)
       await new Promise((resolve, reject) => setTimeout(resolve, delay))
     } else {
       this.debug(`unexpected error. code: ${reject.code}, message: ${reject.message}, data: ${reject.data.toString('hex')}`)

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -778,7 +778,7 @@ describe('Connection', function () {
       clock.restore()
     })
 
-    it('should set the packet amount to a minimum of 1 when it gets T04 errors', async function () {
+    it('should set the packet amount to a minimum of 2 when it gets T04 errors', async function () {
       const clock = sinon.useFakeTimers({
         toFake: ['setTimeout'],
       })
@@ -799,12 +799,55 @@ describe('Connection', function () {
         .callThrough()
 
       const clientStream = this.clientConn.createStream()
-      await clientStream.sendTotal(1)
-      assert.equal(IlpPacket.deserializeIlpPrepare(sendDataStub.args[0][0]).amount, '1')
-      assert.equal(IlpPacket.deserializeIlpPrepare(sendDataStub.args[1][0]).amount, '1')
+      await clientStream.sendTotal(2)
+      assert.equal(IlpPacket.deserializeIlpPrepare(sendDataStub.args[0][0]).amount, '2')
+      assert.equal(IlpPacket.deserializeIlpPrepare(sendDataStub.args[1][0]).amount, '2')
       clearInterval(interval)
       clock.restore()
 
+    })
+
+
+    it('should reduce packet amount then increase it if T04 errors and then successfully sent packets', async function () {
+      const rejectPacket = IlpPacket.serializeIlpReject({
+          code: 'T04',
+          message: 'Insufficient Liquidity Error',
+          data: Buffer.alloc(0),
+          triggeredBy: 'test.connector'
+      })
+
+      // Reject the packet 10 times with T04 error using send total of 1000
+      // to recreate stuck in loop and hung issue
+      const sendDataStub = sinon.stub(this.clientPlugin, 'sendData')
+        .onFirstCall().resolves(rejectPacket)
+        .onSecondCall().resolves(rejectPacket)
+        .onCall(3).resolves(rejectPacket)
+        .onCall(4).resolves(rejectPacket)
+        .onCall(5).resolves(rejectPacket)
+        .onCall(8).resolves(rejectPacket)
+        .onCall(9).resolves(rejectPacket)
+        .onCall(14).resolves(rejectPacket)
+        .onCall(15).resolves(rejectPacket)
+        .callThrough()
+
+      const sendTotal = 1000
+
+      let totalSent = 0
+
+      this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
+        stream.on('close', () => {
+          assert.equal(sendTotal, totalSent)
+          assert.equal(500, Number(stream.totalReceived))
+        })
+      })
+
+      const clientStream = this.clientConn.createStream()
+      clientStream.on('close', () => {
+        totalSent =+ Number(clientStream.totalSent)
+      })
+
+      await clientStream.sendTotal(sendTotal)
+      clientStream.end()
     })
 
     it('should retry on temporary errors', async function () {


### PR DESCRIPTION
- Brings in the Retry delay logic 
- Resolves the reduce to 0 and NaN exchange rate errrors
- Increases the packet amount after T04 errors stop so we are not stuck at a low packet amount indefinitely of 2. 