### PR TITLE
fix: add retry back off for T04 errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,13 +206,13 @@ export class Server extends EventEmitter {
       const localAddressParts = prepare.destination.replace(this.sourceAccount + '.', '').split('.')
       if (localAddressParts.length === 0 || !localAddressParts[0]) {
         this.debug(`destination in ILP Prepare packet does not have a Connection ID: ${prepare.destination}`)
-        throw new IlpPacket.Errors.UnreachableError('')
+        throw new IlpPacket.Errors.UnreachableError('Error in ilp-protocol-stream')
       }
       const connectionId = localAddressParts[0]
 
       if (this.closedConnections[connectionId]) {
         this.debug(`got packet for connection that was already closed: ${connectionId}`)
-        throw new IlpPacket.Errors.UnreachableError('')
+        throw new IlpPacket.Errors.UnreachableError('Error in ilp-protocol-stream')
       }
 
       if (!this.connections[connectionId]) {
@@ -223,7 +223,7 @@ export class Server extends EventEmitter {
           cryptoHelper.decrypt(sharedSecret, prepare.data)
         } catch (err) {
           this.debug(`got prepare for an address and token that we did not generate: ${prepare.destination}`)
-          throw new IlpPacket.Errors.UnreachableError('')
+          throw new IlpPacket.Errors.UnreachableError('Error in ilp-protocol-stream')
         }
 
         // If we get here, that means it was a token + sharedSecret we created

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,13 +206,21 @@ export class Server extends EventEmitter {
       const localAddressParts = prepare.destination.replace(this.sourceAccount + '.', '').split('.')
       if (localAddressParts.length === 0 || !localAddressParts[0]) {
         this.debug(`destination in ILP Prepare packet does not have a Connection ID: ${prepare.destination}`)
-        throw new IlpPacket.Errors.UnreachableError('Error in ilp-protocol-stream')
+        /* Why no error message here?
+        We return an empty message here because we want to minimize the amount of information sent unencrypted
+        that identifies this protocol and specific implementation for the rest of the network. For example,
+        if every implementation returns a slightly different message here, you could determine what type of
+        endpoint is listening on a particular ILP address just by changing the last character of the destination
+        in a packet and seeing what error message you get back.
+        Apologies if this caused additional debugging time for you! */
+        throw new IlpPacket.Errors.UnreachableError('')
       }
       const connectionId = localAddressParts[0]
 
       if (this.closedConnections[connectionId]) {
         this.debug(`got packet for connection that was already closed: ${connectionId}`)
-        throw new IlpPacket.Errors.UnreachableError('Error in ilp-protocol-stream')
+        // See "Why no error message here?" note above
+        throw new IlpPacket.Errors.UnreachableError('')
       }
 
       if (!this.connections[connectionId]) {
@@ -223,7 +231,8 @@ export class Server extends EventEmitter {
           cryptoHelper.decrypt(sharedSecret, prepare.data)
         } catch (err) {
           this.debug(`got prepare for an address and token that we did not generate: ${prepare.destination}`)
-          throw new IlpPacket.Errors.UnreachableError('Error in ilp-protocol-stream')
+          // See "Why no error message here?" note above
+          throw new IlpPacket.Errors.UnreachableError('')
         }
 
         // If we get here, that means it was a token + sharedSecret we created

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -807,7 +807,6 @@ describe('Connection', function () {
 
     })
 
-
     it('should reduce packet amount then increase it if T04 errors and then successfully sent packets', async function () {
       const rejectPacket = IlpPacket.serializeIlpReject({
           code: 'T04',
@@ -832,22 +831,17 @@ describe('Connection', function () {
 
       const sendTotal = 1000
 
-      let totalSent = 0
-
-      this.serverConn.on('stream', (stream: DataAndMoneyStream) => {
-        stream.on('close', () => {
-          assert.equal(sendTotal, totalSent)
-          assert.equal(500, Number(stream.totalReceived))
-        })
-      })
-
+      const spy = sinon.spy()
       const clientStream = this.clientConn.createStream()
       clientStream.on('close', () => {
-        totalSent =+ Number(clientStream.totalSent)
+        spy()
+        assert.equal(clientStream.totalSent, sendTotal)
       })
 
       await clientStream.sendTotal(sendTotal)
-      clientStream.end()
+      await clientStream.end()
+      await new Promise(setImmediate)
+      assert.calledOnce(spy)
     })
 
     it('should retry on temporary errors', async function () {


### PR DESCRIPTION
Add back the logic to increase the retry time for T04 errors.
Add error message to indicate the issue originates from the ilp-protocol-stream module. 