### PR TITLE
Support exchange rates with large scale differences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,9 +1255,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
-      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
     },
     "long": {
@@ -1369,14 +1369,14 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nise": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
-      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
+      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.6.0",
+        "lolex": "2.7.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -4368,16 +4368,16 @@
       }
     },
     "sinon": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
-      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.1.tgz",
+      "integrity": "sha512-rfszhNcfamK2+ofIPi9XqeH89pH7KGDcAtM+F9CsjHXOK3jzWG99vyhyD2V+r7s4IipmWcWUFYq4ftZ9/Eu2Wg==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
-        "nise": "1.3.3",
+        "lolex": "2.7.0",
+        "nise": "1.4.2",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mocha": "^5.1.1",
     "mocha-typescript": "^1.1.14",
     "nyc": "^11.8.0",
-    "sinon": "^4.5.0",
+    "sinon": "^6.0.1",
     "ts-node": "^5.0.1",
     "tslint": "^5.10.0",
     "tslint-config-standard": "^7.0.0",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1063,10 +1063,10 @@ export class Connection extends EventEmitter {
    * @private
    */
   protected async sendTestPacket (amount: BigNumber): Promise<Packet | IlpPacket.IlpRejection> {
-    this.log.trace(`sending test packet for amount: ${amount}`)
-
     // Set packet number to correlate response with request
     const requestPacket = new Packet(this.nextPacketSequence++, IlpPacketType.Prepare)
+
+    this.log.trace(`sending test packet ${requestPacket.sequence} for amount: ${amount}`)
 
     if (!this.remoteKnowsOurAccount) {
       this.log.trace('sending source address to peer')
@@ -1100,6 +1100,8 @@ export class Connection extends EventEmitter {
         this.log.error(`response packet was on wrong ILP packet type. expected ILP packet type: ${responseData[0]}, got:`, JSON.stringify(responsePacket))
         throw new Error(`Response says it should be on an ILP packet of type: ${responsePacket.ilpPacketType} but it was carried on an ILP packet of type: ${responseData[0]}`)
       }
+    } else {
+      this.log.debug(`test packet ${requestPacket.sequence} was rejected with a ${ilpReject.code} error${ilpReject.message ? ' with the message: "' + ilpReject.message + '"' : ''}`)
     }
 
     if (responsePacket) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -103,7 +103,7 @@ describe('Server', function () {
         plugin: this.clientPlugin,
         destinationAccount: destinationAccount + '456',
         sharedSecret
-      }), 'Error connecting: Unexpected error while sending packet. Code: F02, message: ')
+      }), 'Error connecting: Unable to determine path exchange rate')
 
       assert.notCalled(spy)
     })
@@ -199,7 +199,7 @@ describe('Server', function () {
         plugin: this.clientPlugin,
         sharedSecret: this.sharedSecret,
         destinationAccount: this.destinationAccount
-      }), 'Error connecting: Unexpected error while sending packet. Code: F02, message:')
+      }), 'Error connecting: Unable to determine path exchange rate')
     })
 
     it('should remove the record of closed connections', async function () {

--- a/test/mocks/plugin.ts
+++ b/test/mocks/plugin.ts
@@ -72,7 +72,7 @@ export default class MockPlugin extends EventEmitter {
       }
       const newPacket = IlpPacket.serializeIlpPrepare({
         ...parsed,
-        amount: amount.times(this.exchangeRate).toString(10)
+        amount: amount.times(this.exchangeRate).decimalPlaces(0, BigNumber.ROUND_DOWN).toString(10)
       })
       return this.mirror.dataHandler(newPacket)
     } else {


### PR DESCRIPTION
Sends multiple packets at once (1-10^9) to determine the exchange rate

Open question is how it should handle temporary errors (T04s and others) that it gets while sending the initial test packets.

Resolves https://github.com/interledgerjs/ilp-protocol-stream/issues/34