### PR TITLE
feat: support minExchangeRatePrecision

### DIFF
--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -524,10 +524,11 @@ describe('Connection', function () {
       this.clientPlugin.exchangeRate = 0.001
       this.clientPlugin.maxAmount = 150000
 
-      await createConnection({
+      const connection = await createConnection({
         ...this.server.generateAddressAndSecret(),
         plugin: this.clientPlugin
       })
+      assert.equal(connection.minimumAcceptableExchangeRate, '0.001')
 
       clearInterval(interval)
       clock.restore()


### PR DESCRIPTION
Replaces PR #47 default the min precision to 3 digits. 
Only check the prepare amount as discussed in #48 
Update F08 retry logic to support different F08 max packet amounts / allows different updated retry logic for future changes. 