### PR TITLE
data read/write fixes

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -819,6 +819,7 @@ export class Connection extends EventEmitter {
     for (let [_, stream] of this.streams) {
       if (stream.isOpen()) {
         requestPacket.frames.push(new StreamMaxMoneyFrame(stream.id, stream.receiveMax, stream.totalReceived))
+        requestPacket.frames.push(new StreamMaxDataFrame(stream.id, stream._getIncomingOffsets().maxAcceptable))
       }
     }
     if (this.closed && !this.remoteClosed) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -888,6 +888,10 @@ export class Connection extends EventEmitter {
 
     for (let [_, stream] of this.streams) {
       // TODO use a sensible estimate for the StreamDataFrame overhead
+      if (bytesLeftInPacket - 20 <= 0) {
+        // Never pass a negative offset to _getAmountAvailableToSend.
+        break
+      }
       const { data, offset } = stream._getAvailableDataToSend(bytesLeftInPacket - 20)
       if (data && data.length > 0) {
         const streamDataFrame = new StreamDataFrame(stream.id, offset, data)

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -152,7 +152,7 @@ export class DataAndMoneyStream extends Duplex {
    * This property exists on streams after Node 9.4 so it is added here for backwards compatibility
    */
   get writableLength (): number {
-    // stream.readableLength was only added in Node v9.4.0
+    // stream.writableLength was only added in Node v9.4.0
     const writableLength = super.writableLength || (this['_writableState'] && this['_writableState'].length) || 0
     return writableLength
   }
@@ -537,6 +537,12 @@ export class DataAndMoneyStream extends Duplex {
   _read (size: number): void {
     const data = this._incomingData.read()
     if (!data) {
+      // Let the peer know that this stream can receive more data.
+      // Don't call immediately since looping before the read() has finished
+      // would report incorrect offsets.
+      if (this["readableFlowing"] !== true) {
+        process.nextTick(() => this.emit('_maybe_start_send_loop'))
+      }
       return
     }
     this.push(data)

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -540,7 +540,7 @@ export class DataAndMoneyStream extends Duplex {
       // Let the peer know that this stream can receive more data.
       // Don't call immediately since looping before the read() has finished
       // would report incorrect offsets.
-      if (this["readableFlowing"] !== true) {
+      if (this['readableFlowing'] !== true) {
         process.nextTick(() => this.emit('_maybe_start_send_loop'))
       }
       return


### PR DESCRIPTION
#### fix: prevent a stall on idle streams  

Previously, if the reader stream was in paused mode (i.e. calling `read()`, no `"data"` events) it could get stuck by never notifying the peer that the data was read.

Fixed by:

- reader should send a `StreamMaxData` frame during `loadAndSendPacket`, not just on packet responses.
- Start a send loop during `read()` when paused.

-------

#### fix: never request negative data  

I wasn't able to write a test case that caught this, but the bug is:

When the offset passed at https://github.com/interledgerjs/ilp-protocol-stream/blob/26cdd2c8530035af417f9a7d2ace842f3dc2c321/src/connection.ts#L890 is negative, and there is a chunk in the retry queue, the `size` parameter will be used to slice the data buffer -- which actually takes data from the end of the buffer.