### PR TITLE
fix: persist keys and upgrade oer-utils for performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1077,9 +1077,17 @@
       "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.1.2.tgz",
       "integrity": "sha512-LTPA2cwtBGOSiHuspdESKRXQT8CCoGVIUQAeHlNKDz132qwtwwd7KPVWAbGkZer7EQaLW1Cwa9vGR61sSYINww==",
       "requires": {
+        "@types/debug": "^0.0.30",
         "debug": "^4.0.0",
         "source-map-support": "^0.5.9",
         "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "@types/debug": {
+          "version": "0.0.30",
+          "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+          "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+        }
       }
     },
     "ilp-packet": {
@@ -1444,13 +1452,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1619,7 +1627,6 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2683,8 +2690,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3903,9 +3909,9 @@
       "dev": true
     },
     "oer-utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.0.1.tgz",
-      "integrity": "sha512-cyVlY/pP3zhfb9cpv/lcMlVejaVSLJo4Y5ExP39dEcTYP8JwCReWbglOhFNnxLJT3PFQi+6IHHfOWuDmjW9LyA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.1.1.tgz",
+      "integrity": "sha512-Y6+hgPB/yNWJx7WRb4XKin96sTBSAqYPx5p+73X+cAGFuJYupnkwHGTyZvcXPpxGj9rC2oC5uIWDZU8Qdb+Jlw==",
       "requires": {
         "bignumber.js": "^7.2.1"
       }
@@ -4611,7 +4617,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ilp-logger": "^1.1.2",
     "ilp-packet": "^3.0.0",
     "ilp-protocol-ildcp": "^2.0.0",
-    "oer-utils": "^3.0.1",
+    "oer-utils": "^3.1.1",
     "source-map-support": "^0.5.6"
   },
   "devDependencies": {

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -14,7 +14,6 @@ const FULFILLMENT_GENERATION_STRING = Buffer.from('ilp_stream_fulfillment', 'utf
 const TOKEN_LENGTH = 18
 const SHARED_SECRET_GENERATION_STRING = Buffer.from('ilp_stream_shared_secret', 'utf8')
 
-const sharedSecretMap = new Map()
 const fulfillmentKeyMap = new Map()
 const pskKeyMap = new Map()
 
@@ -29,12 +28,8 @@ export function generateTokenAndSharedSecret (seed: Buffer): { token: Buffer, sh
 }
 
 export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buffer {
-  let sharedSecret = sharedSecretMap.get(token)
-  if (!sharedSecret) {
-    const keygen = hmac(seed, SHARED_SECRET_GENERATION_STRING)
-    sharedSecret = hmac(keygen, token)
-    sharedSecretMap.set(token, sharedSecret)
-  }
+  const keygen = hmac(seed, SHARED_SECRET_GENERATION_STRING)
+  const sharedSecret = hmac(keygen, token)
   return sharedSecret
 }
 


### PR DESCRIPTION
- [ ] Changes crypto.ts to persist sharedSecrets, pskKeys, and fulfillment keys using Maps so we are not regenerating the same keys over and over again resulting in a performance increase. 
- [ ] Updates oer-utils to 3.1.1 for performance.