### PR TITLE
feat: multiple connection tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { Connection, ConnectionOpts } from './connection'
 import { Plugin } from './util/plugin-interface'
 require('source-map-support').install()
 
-const CONNECTION_ID_REGEX = /^[a-zA-Z0-9_-~]+$/
+const CONNECTION_ID_REGEX = /^[a-zA-Z0-9~_-]+$/
 
 export { Connection } from './connection'
 export { DataAndMoneyStream } from './stream'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { Connection, ConnectionOpts } from './connection'
 import { Plugin } from './util/plugin-interface'
 require('source-map-support').install()
 
-const CONNECTION_ID_REGEX = /^[a-zA-Z0-9_-]+$/
+const CONNECTION_ID_REGEX = /^[a-zA-Z0-9_-~]+$/
 
 export { Connection } from './connection'
 export { DataAndMoneyStream } from './stream'
@@ -191,7 +191,7 @@ export class Server extends EventEmitter {
     let token = base64url(cryptoHelper.generateToken())
     if (connectionTag) {
       if (!CONNECTION_ID_REGEX.test(connectionTag)) {
-        throw new Error('connectionTag can only include ASCII characters a-z, A-Z, 0-9, "_", and "-"')
+        throw new Error('connectionTag can only include ASCII characters a-z, A-Z, 0-9, "_", "-", and "~"')
       }
       token = token + '~' + connectionTag
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -124,7 +124,7 @@ describe('Server', function () {
 
     it('should throw an error if the connectionTag includes characters that cannot go into an ILP address', async function () {
       await this.server.listen()
-      assert.throws(() => this.server.generateAddressAndSecret('invalid\n'), 'connectionTag can only include ASCII characters a-z, A-Z, 0-9, "_", and "-"')
+      assert.throws(() => this.server.generateAddressAndSecret('invalid\n'), 'connectionTag can only include ASCII characters a-z, A-Z, 0-9, "_", "-", and "~"')
     })
   })
 


### PR DESCRIPTION
Allow '~' as a character for connection tags. It is a valid ilp address
character, and functions as a delimeter to be able to include more 
than one tag.