### PR TITLE
chore: update ilp-logger to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,8 +174,7 @@
     "@types/debug": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.31.tgz",
-      "integrity": "sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==",
-      "dev": true
+      "integrity": "sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A=="
     },
     "@types/events": {
       "version": "1.2.0",
@@ -1073,20 +1072,22 @@
       }
     },
     "ilp-logger": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.1.2.tgz",
-      "integrity": "sha512-LTPA2cwtBGOSiHuspdESKRXQT8CCoGVIUQAeHlNKDz132qwtwwd7KPVWAbGkZer7EQaLW1Cwa9vGR61sSYINww==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.1.3.tgz",
+      "integrity": "sha512-zjCe82YGI1SMnwDf2GGKhGqx0V4UcpReZSiYuBy9KvyOW08Da4geOJfhNd+h9jczDIQ+mFxrbeKoBa/Zbs/5xw==",
       "requires": {
-        "@types/debug": "^0.0.30",
-        "debug": "^4.0.0",
-        "source-map-support": "^0.5.9",
+        "@types/debug": "^0.0.31",
+        "debug": "^4.1.0",
         "supports-color": "^5.5.0"
       },
       "dependencies": {
-        "@types/debug": {
-          "version": "0.0.30",
-          "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
-          "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^10.12.2",
     "bignumber.js": "^7.2.1",
     "debug": "^4.0.0",
-    "ilp-logger": "^1.1.2",
+    "ilp-logger": "^1.1.3",
     "ilp-packet": "^3.0.2",
     "ilp-protocol-ildcp": "^2.0.0",
     "oer-utils": "^3.2.0",


### PR DESCRIPTION
Update to new ilp-logger version which does not include the source map files which will reduce the size of stream by ~100kb when webpacked. 