### PR TITLE
skip volley

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,60 +208,10 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.31.tgz",
       "integrity": "sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A=="
     },
-    "@types/events": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-      "dev": true
-    },
-    "@types/fs-extra": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
-      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
-      "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/handlebars": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
-      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
-      "dev": true
-    },
-    "@types/highlight.js": {
-      "version": "9.12.3",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
-      "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.117",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-      "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==",
-      "dev": true
-    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
-    },
-    "@types/marked": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
-      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -286,16 +236,6 @@
       "integrity": "sha512-ReWZvoEfMiJIA3AG+eM+nCx5GKrU2ANVYY5TC0nbpeiTCtnJbcqnmBbR8TkXMBTvLBYcuTOAELbTcuX73siDNQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/shelljs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
-      "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "*",
         "@types/node": "*"
       }
     },
@@ -850,6 +790,15 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -2995,12 +2944,12 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
@@ -3103,9 +3052,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
       "dev": true
     },
     "hmac-drbg": {
@@ -3418,9 +3367,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
     "invert-kv": {
@@ -3642,6 +3591,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3814,6 +3769,12 @@
         "yallist": "^2.1.2"
       }
     },
+    "lunr": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.7.tgz",
+      "integrity": "sha512-HjFSiy0Y0qZoW5OA1I6qBi7OnsDdqQnaUr03jhorh30maQoaP+4lQCKklYE3Nq3WJMSUfuBl6N+bKY5wxCb9hw==",
+      "dev": true
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -3875,9 +3836,9 @@
       }
     },
     "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true
     },
     "md5.js": {
@@ -5661,9 +5622,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -6173,9 +6134,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -6899,54 +6860,66 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.13.0.tgz",
-      "integrity": "sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
+      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "^5.0.3",
-        "@types/handlebars": "^4.0.38",
-        "@types/highlight.js": "^9.12.3",
-        "@types/lodash": "^4.14.110",
-        "@types/marked": "^0.4.0",
         "@types/minimatch": "3.0.3",
-        "@types/shelljs": "^0.8.0",
-        "fs-extra": "^7.0.0",
-        "handlebars": "^4.0.6",
-        "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
-        "marked": "^0.4.0",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.1.2",
+        "highlight.js": "^9.15.8",
+        "lodash": "^4.17.15",
+        "marked": "^0.7.0",
         "minimatch": "^3.0.0",
-        "progress": "^2.0.0",
-        "shelljs": "^0.8.2",
-        "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.1.x"
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.3",
+        "typedoc-default-themes": "^0.6.0",
+        "typescript": "3.5.x"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-          "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
+            "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
         },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "typescript": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.2.tgz",
-          "integrity": "sha512-gOoGJWbNnFAfP9FlrSV63LYD5DJqYJHG5ky1kOXSl3pCImn4rqWy/flyq1BRd4iChQsoCqjbQaqtmXO4yCVPCA==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
+      "integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
+      "dev": true,
+      "requires": {
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.6",
+        "underscore": "^1.9.1"
+      }
     },
     "typescript": {
       "version": "3.6.3",
@@ -6955,24 +6928,30 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
+      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true,
           "optional": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.10.0",
     "tslint-config-standard": "^8.0.0",
-    "typedoc": "^0.13.0",
+    "typedoc": "^0.15.0",
     "typescript": "^3.6.0",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.7"

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -510,8 +510,13 @@ export class Connection extends EventEmitter {
           }
 
           // Respond with a StreamClose frame (unless there is already one queued)
-          const framesToSend = responseFrames.concat(this.queuedFrames)
-          const includesStreamClose = framesToSend.find((frame) => frame.type === FrameType.StreamClose && frame.streamId.equals(streamId))
+          const testStreamClose = (frame: Frame): boolean => {
+            return frame.type === FrameType.StreamClose
+                && frame.streamId.equals(streamId)
+          }
+          const includesStreamClose
+            = responseFrames.find(testStreamClose)
+            || this.queuedFrames.find(testStreamClose)
           if (!includesStreamClose) {
             responseFrames.push(new StreamCloseFrame(streamId, ErrorCode.StreamStateError, 'Stream is already closed'))
           }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -75,14 +75,14 @@ export interface ConnectionOpts {
   /** Inactivity timeout (milliseconds) */
   idleTimeout?: number,
   /**
-   * Fixed maximum packet amount. When set, the minimum of this setting and the path's
-   * discovered maximum amount is used.
+   * Fixed maximum packet amount. When set, the connection's maximum packet amount
+   * is the minimum of this setting and the path's discovered maximum amount.
    */
   maximumPacketAmount?: string,
   /**
    * Fixed exchange rate. When set, the connection skips the packet volley step.
-   * Note that the minimum acceptable exchange rate is usually smaller than this
-   * (depending on the slippage).
+   * Note that the minimum acceptable exchange rate is usually slightly lower than
+   * this (depending on the connection's slippage).
    *
    * This option should usually be used in concert with `ConnectionOpts.maximumPacketAmount`.
    */
@@ -1163,7 +1163,7 @@ export class Connection extends EventEmitter {
       // ConnectionNewAddressFrame and ConnectionAssetDetailsFrame) to make sure
       // that the connection is valid. This doesn't guarantee that money can be
       // sent at the fixed exchange rate.
-      const res = await this.sendTestPacket(Long.UZERO)
+      const _res = await this.sendTestPacket(Long.UZERO)
       if (!this.remoteKnowsOurAccount) {
         throw new Error('probe packet failed')
       }

--- a/src/util/congestion.ts
+++ b/src/util/congestion.ts
@@ -1,0 +1,103 @@
+import * as Long from 'long'
+import createLogger from 'ilp-logger'
+import * as IlpPacket from 'ilp-packet'
+import { Reader } from 'oer-utils'
+import {
+  checkedAdd,
+  checkedMultiply,
+  maxLong,
+  minLong,
+  multiplyDivideFloor
+} from './long'
+
+const log = createLogger('ilp-protocol-stream:Congestion')
+
+export class CongestionController {
+  /** Used to probe for the Maximum Packet Amount if the connectors don't tell us directly */
+  private _testMaximumPacketAmount: Long
+  /** The path's Maximum Packet Amount, discovered through F08 errors */
+  private _maximumPacketAmount: Long
+
+  constructor () {
+    this._testMaximumPacketAmount = Long.MAX_UNSIGNED_VALUE
+    this._maximumPacketAmount = Long.MAX_UNSIGNED_VALUE
+  }
+
+  get testMaximumPacketAmount (): Long {
+    return this._testMaximumPacketAmount
+  }
+
+  get maximumPacketAmount (): Long {
+    return this._maximumPacketAmount
+  }
+
+  setMaximumAmounts (amount: Long) {
+    this._testMaximumPacketAmount = amount
+    this._maximumPacketAmount = amount
+  }
+
+  onFulfill (amountSent: Long) {
+    const shouldRaiseLimit = amountSent.equals(this._testMaximumPacketAmount)
+      && this._testMaximumPacketAmount.lessThan(this._maximumPacketAmount)
+    if (!shouldRaiseLimit) return
+    // If we're trying to pinpoint the Maximum Packet Amount, raise
+    // the limit because we know that the testMaximumPacketAmount works
+
+    let newTestMax
+    const isMaxPacketAmountKnown =
+      this._maximumPacketAmount.notEquals(Long.MAX_UNSIGNED_VALUE)
+    if (isMaxPacketAmountKnown) {
+      // Take the `max packet amount / 10` and then add it to the last test packet amount for an additive increase.
+      const additiveIncrease = this._maximumPacketAmount.divide(10)
+      newTestMax = minLong(
+        checkedAdd(this._testMaximumPacketAmount, additiveIncrease).sum,
+        this._maximumPacketAmount)
+      log.trace('last packet amount was successful (max packet amount: %s), raising packet amount from %s to: %s', this._maximumPacketAmount, this._testMaximumPacketAmount, newTestMax)
+    } else {
+      // Increase by 2 times in this case since we do not know the max packet amount
+      newTestMax = checkedMultiply(
+        this._testMaximumPacketAmount,
+        Long.fromNumber(2, true)).product
+      log.trace('last packet amount was successful, unknown max packet amount, raising packet amount from: %s to: %s', this._testMaximumPacketAmount, newTestMax)
+    }
+    this._testMaximumPacketAmount = newTestMax
+  }
+
+  // Returns the new maximum packet amount.
+  onAmountTooLargeError (reject: IlpPacket.IlpReject, amountSent: Long): Long {
+    let receivedAmount: Long | undefined
+    let maximumAmount: Long | undefined
+    try {
+      const reader = Reader.from(reject.data)
+      receivedAmount = reader.readUInt64Long()
+      maximumAmount = reader.readUInt64Long()
+    } catch (err) {
+      receivedAmount = undefined
+      maximumAmount = undefined
+    }
+
+    if (receivedAmount && maximumAmount && receivedAmount.greaterThan(maximumAmount)) {
+      const newMaximum = multiplyDivideFloor(amountSent, maximumAmount, receivedAmount)
+      log.trace('reducing maximum packet amount from %s to %s', this._maximumPacketAmount, newMaximum)
+      this._maximumPacketAmount = newMaximum
+      this._testMaximumPacketAmount = newMaximum
+    } else {
+      // Connector didn't include amounts
+      this._maximumPacketAmount = amountSent.subtract(1)
+      this._testMaximumPacketAmount = this._maximumPacketAmount.divide(2)
+    }
+    return this._maximumPacketAmount
+  }
+
+  onInsufficientLiquidityError (reject: IlpPacket.IlpReject, amountSent: Long) {
+    // TODO add more sophisticated logic for handling bandwidth-related connector errors
+    // we should really be keeping track of the amount sent within a given window of time
+    // and figuring out the max amount per window. this logic is just a stand in to fix
+    // infinite retries when it runs into this type of error
+    const minPacketAmount = minLong(amountSent, this._testMaximumPacketAmount)
+    const newTestAmount = minPacketAmount.subtract(minPacketAmount.divide(3))
+    // don't let it go to zero, set to 2 so that the other side gets at least 1 after the exchange rate is taken into account
+    this._testMaximumPacketAmount = maxLong(Long.fromNumber(2, true), newTestAmount)
+    log.warn('got T04: Insufficient Liquidity error triggered by: %s reducing the packet amount to %s', reject.triggeredBy, this._testMaximumPacketAmount)
+  }
+}

--- a/src/util/rational.ts
+++ b/src/util/rational.ts
@@ -77,6 +77,7 @@ export default class Rational {
     return multiplyDivideCeil(value, this.a, this.b)
   }
 
+  // TODO prevent overflows by reducing fraction when necessary
   multiplyByRational (other: Rational): Rational {
     return new Rational(
       this.a.multiply(other.a),

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1043,7 +1043,7 @@ describe('Connection', function () {
         ...this.server.generateAddressAndSecret(),
         plugin: this.clientPlugin
       })
-      assert.equal(clientConn['maximumPacketAmount'].toString(), '1500')
+      assert.equal(clientConn['congestion'].maximumPacketAmount.toString(), '1500')
     })
 
     it.skip('should keep reducing the packet amount if there are multiple connectors with progressively smaller maximums', async function () {

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1172,6 +1172,17 @@ describe('Connection', function () {
       assert.calledOnce(spy2)
       assert.equal(spy2.args[0][0].message, 'Unexpected error while sending packet. Code: F00, triggered by: test.peerA, message: Total received exceeded MaxUint64')
     })
+
+    it('supports a fixed maximumPacketAmount', async function () {
+      const serverPromise = this.server.acceptConnection()
+      const clientConn = await createConnection({
+        ...this.server.generateAddressAndSecret(),
+        plugin: this.clientPlugin,
+        maximumPacketAmount: '5'
+      })
+      const _serverConn = await serverPromise
+      assert.equal(clientConn['congestion'].maximumPacketAmount.toString(), '5')
+    })
   })
 
   describe('Error Handling', function () {


### PR DESCRIPTION
### Features:

* Add `ConnectionOpts.maximumPacketAmount` option.
* Add `ConnectionOpts.exchangeRate` option. When set, the rate volley is skipped and this fixed rate is used instead.
* Drop the stream connection after too many packets sent (`2^31`).

### Fixes:

* Update typedoc. Hopefully this will fix the `publish_docs` circleci task.
* Some refactoring of congestion control.