### PR TITLE
feat: add getExpiry option to createConnection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,7 +1552,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -3276,29 +3275,30 @@
       }
     },
     "ilp-protocol-ildcp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-2.0.2.tgz",
-      "integrity": "sha512-imKeesH2+nNRTohfAjNmcesvD72hgtdlvHtrqPNqx+rtTsnhNIWfpBHEKjKWavDvZNmteuxjM7uEnc0gHF+gpw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-2.1.4.tgz",
+      "integrity": "sha512-+DUJlbacQTKrI+Pmnz/PH9luX78dOiRTHG+xQzm3MXD0PO0oYLt35t9d+nfzSyba0S+4QQEnAOv8eEnFZwcW0A==",
       "requires": {
         "debug": "^3.1.0",
-        "ilp-packet": "^3.0.9",
-        "oer-utils": "^5.0.1"
+        "ilp-packet": "^3.1.0-alpha.0",
+        "oer-utils": "^5.1.0-alpha.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "ilp-packet": {
+          "version": "3.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.1.0-alpha.0.tgz",
+          "integrity": "sha512-GGzY9ftkfsPXAMlcJEwUCSzewecKKsYmw3gHLIT90YjpgQW56Xr0HDanNEHjnrMyBYkwjUf48zxEB9tHZCVkEw==",
           "requires": {
-            "ms": "^2.1.1"
+            "extensible-error": "^1.0.2",
+            "oer-utils": "^5.1.0-alpha.0"
           }
         },
         "oer-utils": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-5.0.1.tgz",
-          "integrity": "sha512-/+b8EC7RsNBkK+0weoUD55dKa5K2kUAIMM6KY62ssOtu7EyCcqi7idOesaXoUZEYezeZrvu09MOuias/RWVubw==",
+          "version": "5.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-5.1.0-alpha.0.tgz",
+          "integrity": "sha512-PIjF1+jT6DENZe/WfAHU+F/xZ8aLes+TW6Wpalz2t0k2BoOdCQrgrTL/8z9jtOueR152kjxDox3meJXF+LRh3g==",
           "requires": {
-            "@types/long": "^4.0.0",
+            "@types/long": "4.0.0",
             "long": "^4.0.0"
           }
         }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^10.14.22",
     "ilp-logger": "^1.2.1",
     "ilp-packet": "^3.0.9",
-    "ilp-protocol-ildcp": "^2.0.2",
+    "ilp-protocol-ildcp": "^2.1.4",
     "long": "^4.0.0",
     "oer-utils": "^5.0.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,10 @@ export async function createConnection (opts: CreateConnectionOpts): Promise<Con
   const plugin = opts.plugin
   await plugin.connect()
   const log = createLogger('ilp-protocol-stream:Client')
-  const { clientAddress, assetCode, assetScale } = await ILDCP.fetch(plugin.sendData.bind(plugin))
+  const { clientAddress, assetCode, assetScale } =
+    await ILDCP.fetch(plugin.sendData.bind(plugin), {
+      expiresAt: opts.getExpiry && opts.getExpiry('peer.config')
+    })
   const connection = await Connection.build({
     ...opts,
     sourceAccount: clientAddress,


### PR DESCRIPTION
Depends on the ilp-protocol-ildcp change at https://github.com/interledgerjs/interledgerjs/pull/7 (CI will fail until that is updated).

This option is useful in the web extension when the client has a badly skewed clock. The extension can set a fixed, distant `expiresAt` for all Prepare packets. The first connector will automatically [replace it with a sensible value](https://github.com/interledgerjs/ilp-connector/blob/ff20aff6f064945ef4b616baaa06990c2592707a/src/services/route-builder.ts#L122) (`now + maxHoldTime`).