### PR TITLE
chore: Better logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,6 +266,15 @@
         "source-map": "^0.6.1"
       }
     },
+    "@types/uuid": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.6.tgz",
+      "integrity": "sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/webpack": {
       "version": "4.39.1",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.39.1.tgz",
@@ -2275,7 +2284,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2296,12 +2306,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2316,17 +2328,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2443,7 +2458,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2455,6 +2471,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2469,6 +2486,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2476,12 +2494,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2500,6 +2520,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2580,7 +2601,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2592,6 +2614,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2677,7 +2700,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2713,6 +2737,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2732,6 +2757,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2775,12 +2801,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7110,10 +7138,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "ilp-packet": "^3.0.9",
     "ilp-protocol-ildcp": "^2.1.4",
     "long": "^4.0.0",
-    "oer-utils": "^5.0.1"
+    "oer-utils": "^5.0.1",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",
@@ -56,6 +57,7 @@
     "@types/mocha": "^5.2.5",
     "@types/puppeteer": "^1.19.1",
     "@types/sinon": "^5.0.1",
+    "@types/uuid": "^3.4.6",
     "@types/webpack": "^4.39.1",
     "benchmark": "^2.1.4",
     "bignumber.js": "^7.2.1",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -42,6 +42,7 @@ import {
 } from './util/long'
 import * as Long from 'long'
 import Rational from './util/rational'
+import { v4 as uuid } from 'uuid'
 
 const RETRY_DELAY_START = 100
 const RETRY_DELAY_MAX = 43200000 // 12 hours should be long enough
@@ -138,6 +139,7 @@ export class Connection extends EventEmitter {
   /** Application identifier for a certain connection */
   readonly connectionTag?: string
 
+  protected connectionId: string
   protected plugin: Plugin
   protected _sourceAccount: string
   protected _sourceAssetCode: string
@@ -187,6 +189,7 @@ export class Connection extends EventEmitter {
 
   constructor (opts: NewConnectionOpts) {
     super()
+    this.connectionId = uuid()
     this.plugin = opts.plugin
     this._sourceAccount = opts.sourceAccount
     this._sourceAssetCode = opts.assetCode
@@ -218,7 +221,7 @@ export class Connection extends EventEmitter {
     this.streams = new Map()
     this.closedStreams = new Set()
     this.nextStreamId = (this.isServer ? 2 : 1)
-    this.log = createLogger(`ilp-protocol-stream:${this.isServer ? 'Server' : 'Client'}:Connection`)
+    this.log = createLogger(`ilp-protocol-stream:${this.isServer ? 'Server' : 'Client'}:Connection:${this.connectionId}`)
     this.sending = false
     this.connected = false
     this.closed = true
@@ -376,7 +379,8 @@ export class Connection extends EventEmitter {
     // TODO should this inform the other side?
     const stream = new DataAndMoneyStream({
       id: this.nextStreamId,
-      isServer: this.isServer
+      isServer: this.isServer,
+      connectionId: this.connectionId
     })
     this.streams.set(this.nextStreamId, stream)
     this.log.debug('created stream: %d', this.nextStreamId)
@@ -850,7 +854,8 @@ export class Connection extends EventEmitter {
     this.log.info('got new stream: %d', streamId)
     const stream = new DataAndMoneyStream({
       id: streamId,
-      isServer: this.isServer
+      isServer: this.isServer,
+      connectionId: this.connectionId
     })
     this.streams.set(streamId, stream)
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -18,7 +18,8 @@ const MAX_REMOTE_RECEIVE = Long.MAX_UNSIGNED_VALUE
 
 export interface StreamOpts {
   id: number,
-  isServer: boolean
+  isServer: boolean,
+  connectionId: string
 }
 
 export interface SendOpts {
@@ -78,7 +79,7 @@ export class DataAndMoneyStream extends Duplex {
     super({ allowHalfOpen: false })
     this.id = opts.id
     this.isServer = opts.isServer
-    this.log = createLogger(`ilp-protocol-stream:${this.isServer ? 'Server' : 'Client'}:Stream:${this.id}`)
+    this.log = createLogger(`ilp-protocol-stream:${this.isServer ? 'Server' : 'Client'}:Connection:${opts.connectionId}:Stream:${this.id}`)
     this.log.info('new stream created')
 
     this._totalSent = Long.UZERO


### PR DESCRIPTION
Currently debugging logs from STREAM is very difficult when trying to identify logs for a particular STREAM and Connection. This adds a uuid to the connection logging as well as the DataAndMoneyStream. This should allow someone debugging to filter the logs for a particular connection and see its lifecycle easier. Especially Streams in server mode

