### PR TITLE
feat: add receipts

### DIFF
--- a/scripts/generate-fixtures.ts
+++ b/scripts/generate-fixtures.ts
@@ -100,7 +100,12 @@ const variants = Array.prototype.concat.apply([], [
   NUMBERS.map((pair) => ({
     name: 'frame:stream_data_blocked:offset:' + pair.name,
     frame: new Packet.StreamDataBlockedFrame(123, pair.value)
-  }))
+  })),
+  {
+    name: 'frame:stream_receipt',
+    frame: new Packet.StreamReceiptFrame(1,
+      Buffer.from('AQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAfTBIvoCUt67Zy1ZGCP3EOmVFtZzhc85fah8yPnoyL9RMA==', 'base64'))
+  }
 ])
 
 const fixtures = variants.map(function (params: any) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -229,6 +229,9 @@ export class Connection extends EventEmitter {
     this.allowableReceiveExtra = Rational.fromNumber(1.01, true)
     this.enablePadding = !!opts.enablePadding
     this.connectionTag = opts.connectionTag
+    if (!opts.receiptNonce !== !opts.receiptSecret) {
+      throw new Error('receiptNonce and receiptSecret must accompany each other')
+    }
     this._receiptNonce = opts.receiptNonce
     this._receiptSecret = opts.receiptSecret
     this.maxStreamId = 2 * (opts.maxRemoteStreams || DEFAULT_MAX_REMOTE_STREAMS)

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -2,9 +2,9 @@
 import { hmac, randomBytes } from './util/crypto-node'
 export {
   decrypt,
-  decryptToken, // only in node, not browser
+  decryptConnectionAddressToken, // only in node, not browser
   encrypt,
-  encryptToken, // only in node, not browser
+  encryptConnectionAddressToken, // only in node, not browser
   generateSharedSecretFromToken, // only in node, not browser
   generateReceiptHMAC, // only in node, not browser
   hash,
@@ -12,14 +12,14 @@ export {
   randomBytes
 } from './util/crypto-node'
 
-export const TOKEN_LENGTH = 18
+export const TOKEN_NONCE_LENGTH = 18
 const ENCRYPTION_KEY_STRING = Buffer.from('ilp_stream_encryption', 'utf8')
 const FULFILLMENT_GENERATION_STRING = Buffer.from('ilp_stream_fulfillment', 'utf8')
 const PACKET_ID_STRING = Buffer.from('ilp_stream_packet_id', 'utf8')
 export const ENCRYPTION_OVERHEAD = 28
 
-export function generateToken (): Buffer {
-  return randomBytes(TOKEN_LENGTH)
+export function generateTokenNonce (): Buffer {
+  return randomBytes(TOKEN_NONCE_LENGTH)
 }
 
 export function generateRandomCondition (): Buffer {

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -2,13 +2,16 @@
 import { hmac, randomBytes } from './util/crypto-node'
 export {
   decrypt,
+  decryptToken, // only in node, not browser
   encrypt,
+  encryptToken, // only in node, not browser
   generateSharedSecretFromToken, // only in node, not browser
   hash,
+  hmac,
   randomBytes
 } from './util/crypto-node'
 
-const TOKEN_LENGTH = 18
+export const TOKEN_LENGTH = 18
 const ENCRYPTION_KEY_STRING = Buffer.from('ilp_stream_encryption', 'utf8')
 const FULFILLMENT_GENERATION_STRING = Buffer.from('ilp_stream_fulfillment', 'utf8')
 const PACKET_ID_STRING = Buffer.from('ilp_stream_packet_id', 'utf8')

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -6,6 +6,7 @@ export {
   encrypt,
   encryptToken, // only in node, not browser
   generateSharedSecretFromToken, // only in node, not browser
+  generateReceiptHMAC, // only in node, not browser
   hash,
   hmac,
   randomBytes

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Connection, ConnectionOpts } from './connection'
 
 export { Connection } from './connection'
 export { DataAndMoneyStream } from './stream'
-export { Server, ServerOpts, createServer } from './server'
+export { Server, ServerOpts, createServer, GenerateAddressSecretOpts } from './server'
 
 export interface CreateConnectionOpts extends ConnectionOpts {
   /** ILP Address of the server */

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -59,8 +59,8 @@ export class ServerConnectionPool {
       let connectionTag: string | undefined
       let receiptNonce: Buffer | undefined
       let receiptSecret: Buffer | undefined
-      const reader = new Reader(cryptoHelper.decryptToken(this.serverSecret, token))
-      reader.skipOctetString(cryptoHelper.TOKEN_LENGTH)
+      const reader = new Reader(cryptoHelper.decryptConnectionAddressToken(this.serverSecret, token))
+      reader.skipOctetString(cryptoHelper.TOKEN_NONCE_LENGTH)
       if (reader.peekVarOctetString().length) {
         connectionTag = reader.readVarOctetString().toString('ascii')
       } else {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,5 +1,6 @@
 import createLogger from 'ilp-logger'
 import * as IlpPacket from 'ilp-packet'
+import { Reader } from 'oer-utils'
 import { Connection, BuildConnectionOpts } from './connection'
 import * as cryptoHelper from './crypto'
 
@@ -52,15 +53,46 @@ export class ServerConnectionPool {
     if (pendingConnection) return pendingConnection
 
     const connectionPromise = (async () => {
-      const sharedSecret = await this.getSharedSecret(id, prepare)
+      const token = decodeBase64url(id)
+      const sharedSecret = await this.getSharedSecret(token, prepare)
       // If we get here, that means it was a token + sharedSecret we created
-      const tilde = id.indexOf('~')
-      const connectionTag = tilde !== -1 ? id.slice(tilde + 1) : undefined
+      let connectionTag: string | undefined
+      let receiptNonce: Buffer | undefined
+      let receiptSecret: Buffer | undefined
+      const reader = new Reader(cryptoHelper.decryptToken(this.serverSecret, token))
+      reader.skipOctetString(cryptoHelper.TOKEN_LENGTH)
+      if (reader.peekVarOctetString().length) {
+        connectionTag = reader.readVarOctetString().toString('ascii')
+      } else {
+        reader.skipVarOctetString()
+      }
+      switch (reader.peekVarOctetString().length) {
+        case 0:
+          reader.skipVarOctetString()
+          break
+        case 16:
+          receiptNonce = reader.readVarOctetString()
+          break
+        default:
+          throw new Error('receiptNonce must be 16 bytes')
+      }
+      switch (reader.peekVarOctetString().length) {
+        case 0:
+          reader.skipVarOctetString()
+          break
+        case 32:
+          receiptSecret = reader.readVarOctetString()
+          break
+        default:
+          throw new Error('receiptSecret must be 32 bytes')
+      }
       const conn = await Connection.build({
         ...this.connectionOpts,
         sharedSecret,
         connectionTag,
-        connectionId: id
+        connectionId: id,
+        receiptNonce,
+        receiptSecret
       })
       log.debug('got incoming packet for new connection: %s%s', id, (connectionTag ? ' (connectionTag: ' + connectionTag + ')' : ''))
       try {
@@ -92,11 +124,10 @@ export class ServerConnectionPool {
   }
 
   private async getSharedSecret (
-    id: string,
+    token: Buffer,
     prepare: IlpPacket.IlpPrepare
   ): Promise<Buffer> {
     try {
-      const token = Buffer.from(id, 'ascii')
       const sharedSecret = cryptoHelper.generateSharedSecretFromToken(
         this.serverSecret, token)
       // TODO just pass this into the connection?
@@ -108,4 +139,11 @@ export class ServerConnectionPool {
       throw err
     }
   }
+}
+
+function decodeBase64url (str: string) {
+  return Buffer.from(str
+      .replace(/-/g, '+')
+      .replace(/_/g, '/'),
+    'base64')
 }

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -53,7 +53,7 @@ export class ServerConnectionPool {
     if (pendingConnection) return pendingConnection
 
     const connectionPromise = (async () => {
-      const token = decodeBase64url(id)
+      const token = Buffer.from(id, 'base64')
       const sharedSecret = await this.getSharedSecret(token, prepare)
       // If we get here, that means it was a token + sharedSecret we created
       let connectionTag: string | undefined
@@ -139,11 +139,4 @@ export class ServerConnectionPool {
       throw err
     }
   }
-}
-
-function decodeBase64url (str: string) {
-  return Buffer.from(str
-      .replace(/-/g, '+')
-      .replace(/_/g, '/'),
-    'base64')
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,9 +5,9 @@ import createLogger from 'ilp-logger'
 import * as cryptoHelper from './crypto'
 import { Connection, ConnectionOpts } from './connection'
 import { ServerConnectionPool } from './pool'
+import { Predictor, Writer } from 'oer-utils'
 import { Plugin } from './util/plugin-interface'
 
-const CONNECTION_ID_REGEX = /^[a-zA-Z0-9~_-]+$/
 const DEFAULT_DISCONNECT_DELAY = 100
 
 export interface ServerOpts extends ConnectionOpts {
@@ -18,6 +18,12 @@ export interface ServerOpts extends ConnectionOpts {
    * the plugin so packets may be safely returned
    */
   disconnectDelay?: number
+}
+
+export interface GenerateAddressSecretOpts {
+  connectionTag?: string,
+  receiptNonce?: Buffer,
+  receiptSecret?: Buffer
 }
 
 /**
@@ -155,23 +161,61 @@ export class Server extends EventEmitter {
    * Two different clients SHOULD NOT be given the same address and secret.
    *
    * @param connectionTag Optional connection identifier that will be appended to the ILP address and can be used to identify incoming connections. Can only include characters that can go into an ILP Address
+   * @param receiptNonce Optional nonce to include in STREAM receipts
+   * @param receiptSecret Optional secret to use for signing STREAM receipts
    */
-  generateAddressAndSecret (connectionTag?: string): { destinationAccount: string, sharedSecret: Buffer } {
+  generateAddressAndSecret (opts?: string | GenerateAddressSecretOpts): { destinationAccount: string, sharedSecret: Buffer, receiptsEnabled: boolean } {
     if (!this.connected) {
       throw new Error('Server must be connected to generate address and secret')
     }
-    let token = base64url(cryptoHelper.generateToken())
-    if (connectionTag) {
-      if (!CONNECTION_ID_REGEX.test(connectionTag)) {
-        throw new Error('connectionTag can only include ASCII characters a-z, A-Z, 0-9, "_", "-", and "~"')
+    let connectionTag = Buffer.alloc(0)
+    let receiptNonce = Buffer.alloc(0)
+    let receiptSecret = Buffer.alloc(0)
+    let receiptsEnabled = false
+    if (opts) {
+      if (typeof opts === 'object') {
+        if (opts.connectionTag) {
+          connectionTag = Buffer.from(opts.connectionTag, 'ascii')
+        }
+        if (!opts.receiptNonce !== !opts.receiptSecret) {
+          throw new Error('receiptNonce and receiptSecret must accompany each other')
+        }
+        if (opts.receiptNonce) {
+          if (opts.receiptNonce.length !== 16) {
+            throw new Error('receiptNonce must be 16 bytes')
+          }
+          receiptsEnabled = true
+          receiptNonce = opts.receiptNonce
+        }
+        if (opts.receiptSecret) {
+          if (opts.receiptSecret.length !== 32) {
+            throw new Error('receiptSecret must be 32 bytes')
+          }
+          receiptSecret = opts.receiptSecret
+        }
+      } else {
+        connectionTag = Buffer.from(opts, 'ascii')
       }
-      token = token + '~' + connectionTag
     }
-    const sharedSecret = cryptoHelper.generateSharedSecretFromToken(this.serverSecret, Buffer.from(token, 'ascii'))
+    let token = cryptoHelper.generateToken()
+    const predictor = new Predictor()
+    predictor.writeOctetString(token, cryptoHelper.TOKEN_LENGTH)
+    predictor.writeVarOctetString(connectionTag)
+    predictor.writeVarOctetString(receiptNonce)
+    predictor.writeVarOctetString(receiptSecret)
+    const writer = new Writer(predictor.length)
+    writer.writeOctetString(token, cryptoHelper.TOKEN_LENGTH)
+    writer.writeVarOctetString(connectionTag)
+    writer.writeVarOctetString(receiptNonce)
+    writer.writeVarOctetString(receiptSecret)
+
+    token = cryptoHelper.encryptToken(this.serverSecret, writer.getBuffer())
+    const sharedSecret = cryptoHelper.generateSharedSecretFromToken(this.serverSecret, token)
     return {
       // TODO should this be called serverAccount or serverAddress instead?
-      destinationAccount: `${this.serverAccount}.${token}`,
-      sharedSecret
+      destinationAccount: `${this.serverAccount}.${base64url(token)}`,
+      sharedSecret,
+      receiptsEnabled
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -197,19 +197,19 @@ export class Server extends EventEmitter {
         connectionTag = Buffer.from(opts, 'ascii')
       }
     }
-    let token = cryptoHelper.generateToken()
+    const tokenNonce = cryptoHelper.generateTokenNonce()
     const predictor = new Predictor()
-    predictor.writeOctetString(token, cryptoHelper.TOKEN_LENGTH)
+    predictor.writeOctetString(tokenNonce, cryptoHelper.TOKEN_NONCE_LENGTH)
     predictor.writeVarOctetString(connectionTag)
     predictor.writeVarOctetString(receiptNonce)
     predictor.writeVarOctetString(receiptSecret)
     const writer = new Writer(predictor.length)
-    writer.writeOctetString(token, cryptoHelper.TOKEN_LENGTH)
+    writer.writeOctetString(tokenNonce, cryptoHelper.TOKEN_NONCE_LENGTH)
     writer.writeVarOctetString(connectionTag)
     writer.writeVarOctetString(receiptNonce)
     writer.writeVarOctetString(receiptSecret)
 
-    token = cryptoHelper.encryptToken(this.serverSecret, writer.getBuffer())
+    const token = cryptoHelper.encryptConnectionAddressToken(this.serverSecret, writer.getBuffer())
     const sharedSecret = cryptoHelper.generateSharedSecretFromToken(this.serverSecret, token)
     return {
       // TODO should this be called serverAccount or serverAddress instead?

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -71,6 +71,8 @@ export class DataAndMoneyStream extends Duplex {
   protected _outgoingDataToRetry: { data: Buffer, offset: number }[]
   protected outgoingOffset: number
 
+  protected _receipt?: Buffer
+
   protected emittedEnd: boolean
   protected emittedClose: boolean
 
@@ -193,6 +195,13 @@ export class DataAndMoneyStream extends Duplex {
     } else {
       return this['_writableState'].highWaterMark
     }
+  }
+
+  /**
+   * Latest receipt for total sent amount.
+   */
+  get receipt (): Buffer | undefined {
+    return this._receipt
   }
 
   /**
@@ -672,6 +681,14 @@ export class DataAndMoneyStream extends Duplex {
       this.push(null)
       this.end()
     }
+  }
+
+  /**
+   * (Used by the Connection class but not meant to be part of the public API)
+   * @private
+   */
+  _setReceipt (receipt: Buffer): void {
+    this._receipt = receipt
   }
 
   protected safeEmit (event: string, ...args: any[]) {

--- a/src/util/crypto-browser.ts
+++ b/src/util/crypto-browser.ts
@@ -140,12 +140,12 @@ export function generateReceiptHMAC (secret: Buffer, message: Buffer): Buffer {
 
 // Dummy function to make typescript happy. This function is only ever used by
 // the server, which is not included in the browser build.
-export function encryptToken (seed: Buffer, token: Buffer): Buffer {
+export function encryptConnectionAddressToken (seed: Buffer, token: Buffer): Buffer {
   throw new Error('unreachable in browser')
 }
 
 // Dummy function to make typescript happy. This function is only ever used by
 // the server, which is not included in the browser build.
-export function decryptToken (seed: Buffer, token: Buffer): Buffer {
+export function decryptConnectionAddressToken (seed: Buffer, token: Buffer): Buffer {
   throw new Error('unreachable in browser')
 }

--- a/src/util/crypto-browser.ts
+++ b/src/util/crypto-browser.ts
@@ -134,6 +134,12 @@ export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buf
 
 // Dummy function to make typescript happy. This function is only ever used by
 // the server, which is not included in the browser build.
+export function generateReceiptHMAC (secret: Buffer, receipt: Buffer): Buffer {
+  throw new Error('unreachable in browser')
+}
+
+// Dummy function to make typescript happy. This function is only ever used by
+// the server, which is not included in the browser build.
 export function encryptToken (seed: Buffer, token: Buffer): Buffer {
   throw new Error('unreachable in browser')
 }

--- a/src/util/crypto-browser.ts
+++ b/src/util/crypto-browser.ts
@@ -134,7 +134,7 @@ export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buf
 
 // Dummy function to make typescript happy. This function is only ever used by
 // the server, which is not included in the browser build.
-export function generateReceiptHMAC (secret: Buffer, receipt: Buffer): Buffer {
+export function generateReceiptHMAC (secret: Buffer, message: Buffer): Buffer {
   throw new Error('unreachable in browser')
 }
 

--- a/src/util/crypto-browser.ts
+++ b/src/util/crypto-browser.ts
@@ -131,3 +131,15 @@ export function randomBytes (size: number): Buffer {
 export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buffer {
   throw new Error('unreachable in browser')
 }
+
+// Dummy function to make typescript happy. This function is only ever used by
+// the server, which is not included in the browser build.
+export function encryptToken (seed: Buffer, token: Buffer): Buffer {
+  throw new Error('unreachable in browser')
+}
+
+// Dummy function to make typescript happy. This function is only ever used by
+// the server, which is not included in the browser build.
+export function decryptToken (seed: Buffer, token: Buffer): Buffer {
+  throw new Error('unreachable in browser')
+}

--- a/src/util/crypto-node.ts
+++ b/src/util/crypto-node.ts
@@ -16,6 +16,10 @@ export async function hash (preimage: Buffer): Promise<Buffer> {
 }
 
 export async function encrypt (pskEncryptionKey: Buffer, ...buffers: Buffer[]): Promise<Buffer> {
+  return Promise.resolve(encryptSync(pskEncryptionKey, ...buffers))
+}
+
+function encryptSync (pskEncryptionKey: Buffer, ...buffers: Buffer[]): Buffer {
   const iv = crypto.randomBytes(IV_LENGTH)
   const cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, pskEncryptionKey, iv)
 
@@ -26,10 +30,14 @@ export async function encrypt (pskEncryptionKey: Buffer, ...buffers: Buffer[]): 
   ciphertext.push(cipher.final())
   const tag = cipher.getAuthTag()
   ciphertext.unshift(iv, tag)
-  return Promise.resolve(Buffer.concat(ciphertext))
+  return Buffer.concat(ciphertext)
 }
 
 export async function decrypt (pskEncryptionKey: Buffer, data: Buffer): Promise<Buffer> {
+  return Promise.resolve(decryptSync(pskEncryptionKey, data))
+}
+
+function decryptSync (pskEncryptionKey: Buffer, data: Buffer): Buffer {
   assert(data.length > 0, 'cannot decrypt empty buffer')
   const nonce = data.slice(0, IV_LENGTH)
   const tag = data.slice(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH)
@@ -37,10 +45,10 @@ export async function decrypt (pskEncryptionKey: Buffer, data: Buffer): Promise<
   const decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, pskEncryptionKey, nonce)
   decipher.setAuthTag(tag)
 
-  return Promise.resolve(Buffer.concat([
+  return Buffer.concat([
     decipher.update(encrypted),
     decipher.final()
-  ]))
+  ])
 }
 
 export async function hmac (key: Buffer, message: Buffer): Promise<Buffer> {
@@ -57,4 +65,12 @@ export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buf
   const keygen = hmacSync(seed, SHARED_SECRET_GENERATION_STRING)
   const sharedSecret = hmacSync(keygen, token)
   return sharedSecret
+}
+
+export function encryptToken (seed: Buffer, token: Buffer): Buffer {
+  return encryptSync(seed, token)
+}
+
+export function decryptToken (seed: Buffer, token: Buffer): Buffer {
+  return decryptSync(seed, token)
 }

--- a/src/util/crypto-node.ts
+++ b/src/util/crypto-node.ts
@@ -71,10 +71,10 @@ export function generateReceiptHMAC (secret: Buffer, message: Buffer): Buffer {
   return hmacSync(secret, message)
 }
 
-export function encryptToken (seed: Buffer, token: Buffer): Buffer {
+export function encryptConnectionAddressToken (seed: Buffer, token: Buffer): Buffer {
   return encryptSync(seed, token)
 }
 
-export function decryptToken (seed: Buffer, token: Buffer): Buffer {
+export function decryptConnectionAddressToken (seed: Buffer, token: Buffer): Buffer {
   return decryptSync(seed, token)
 }

--- a/src/util/crypto-node.ts
+++ b/src/util/crypto-node.ts
@@ -67,6 +67,10 @@ export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buf
   return sharedSecret
 }
 
+export function generateReceiptHMAC (secret: Buffer, receipt: Buffer): Buffer {
+  return hmacSync(secret, receipt)
+}
+
 export function encryptToken (seed: Buffer, token: Buffer): Buffer {
   return encryptSync(seed, token)
 }

--- a/src/util/crypto-node.ts
+++ b/src/util/crypto-node.ts
@@ -67,8 +67,8 @@ export function generateSharedSecretFromToken (seed: Buffer, token: Buffer): Buf
   return sharedSecret
 }
 
-export function generateReceiptHMAC (secret: Buffer, receipt: Buffer): Buffer {
-  return hmacSync(secret, receipt)
+export function generateReceiptHMAC (secret: Buffer, message: Buffer): Buffer {
+  return hmacSync(secret, message)
 }
 
 export function encryptToken (seed: Buffer, token: Buffer): Buffer {

--- a/src/util/receipt.ts
+++ b/src/util/receipt.ts
@@ -6,8 +6,7 @@ import {
 import * as Long from 'long'
 import { generateReceiptHMAC } from '../crypto'
 
-const RECEIPT_VERSION = 1
-export { RECEIPT_VERSION }
+export const RECEIPT_VERSION = 1
 
 export interface ReceiptOpts {
   nonce: Buffer

--- a/src/util/receipt.ts
+++ b/src/util/receipt.ts
@@ -1,0 +1,71 @@
+import { Reader, Writer } from 'oer-utils'
+import {
+  LongValue,
+  longFromValue
+} from './long'
+import * as Long from 'long'
+import { generateReceiptHMAC } from '../crypto'
+
+const RECEIPT_VERSION = 1
+export { RECEIPT_VERSION }
+
+export interface ReceiptOpts {
+  nonce: Buffer
+  streamId: LongValue
+  totalReceived: LongValue
+  secret: Buffer
+}
+
+export interface Receipt {
+  version: number
+  nonce: Buffer
+  streamId: string
+  totalReceived: Long
+}
+
+export function createReceipt (opts: ReceiptOpts): Buffer {
+  if (opts.nonce.length !== 16) {
+    throw new Error('receipt nonce must be 16 bytes')
+  }
+  if (opts.secret.length !== 32) {
+    throw new Error('receipt secret must be 32 bytes')
+  }
+  const receipt = new Writer(58)
+  receipt.writeUInt8(RECEIPT_VERSION)
+  receipt.writeOctetString(opts.nonce, 16)
+  receipt.writeUInt8(opts.streamId)
+  receipt.writeUInt64(longFromValue(opts.totalReceived, true))
+  receipt.writeOctetString(generateReceiptHMAC(opts.secret, receipt.getBuffer()), 32)
+  return receipt.getBuffer()
+}
+
+export function decodeReceipt (receipt: Buffer): Receipt {
+  if (receipt.length !== 58) {
+    throw new Error('receipt must be 58 bytes')
+  }
+  const reader = Reader.from(receipt)
+  const version = reader.readUInt8Number()
+  const nonce = reader.readOctetString(16)
+  const streamId = reader.readUInt8()
+  const totalReceived = reader.readUInt64Long()
+  return {
+    version,
+    nonce,
+    streamId,
+    totalReceived
+  }
+}
+
+export function verifyReceipt (receipt: Buffer, secret: Buffer): Boolean {
+  if (receipt.length !== 58) {
+    return false
+  }
+  const reader = Reader.from(receipt)
+  if (reader.readUInt8Number() !== RECEIPT_VERSION) {
+    return false
+  }
+  const message = reader.buffer.slice(0, 26)
+  const receiptHmac = reader.buffer.slice(26)
+
+  return receiptHmac.equals(generateReceiptHMAC(secret, message))
+}

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -535,15 +535,16 @@ describe('Connection', function () {
       await clientStream.sendTotal(1002)
 
       const receiptFixture = require('./fixtures/packets.json').find(({ name }: { name: string}) => name === 'frame:stream_receipt' ).packet.frames[0].receipt
-
       assert.calledTwice(spy)
       assert.calledWith(spy.firstCall, receiptFixture)
-      assert.calledWith(spy.secondCall, createReceipt({
+      const receipt = createReceipt({
         nonce: this.receiptNonce,
         streamId: clientStream.id,
         totalReceived: '501',
         secret: this.receiptSecret
-      }))
+      })
+      assert.calledWith(spy.secondCall, receipt)
+      assert(clientStream.receipt.equals(receipt))
     })
   })
 

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -11,9 +11,9 @@ if (typeof describe === 'function') {
 export function runCryptoTests (args: {describe: Mocha.SuiteFunction, it: Mocha.TestFunction}) {
   const { describe, it } = args
 
-  describe('generateToken', function () {
-    it('generates a random 18-byte token', function () {
-      assert.equal(helpers.generateToken().length, 18)
+  describe('generateTokenNonce', function () {
+    it('generates a random 18-byte token nonce', function () {
+      assert.equal(helpers.generateTokenNonce().length, 18)
     })
   })
 

--- a/test/fixtures/packets.json
+++ b/test/fixtures/packets.json
@@ -791,6 +791,23 @@
     "buffer": "AQwBAAEAAQEWCwF7CP//////////"
   },
   {
+    "name": "frame:stream_receipt",
+    "packet": {
+      "sequence": "0",
+      "packetType": 12,
+      "amount": "0",
+      "frames": [
+        {
+          "type": 23,
+          "name": "StreamReceipt",
+          "streamId": "1",
+          "receipt": "AQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAfTBIvoCUt67Zy1ZGCP3EOmVFtZzhc85fah8yPnoyL9RMA=="
+        }
+      ]
+    },
+    "buffer": "AQwBAAEAAQEXPQEBOgEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAH0wSL6AlLeu2ctWRgj9xDplRbWc4XPOX2ofMj56Mi/UTA="
+  },
+  {
     "name": "frame:stream_max_money:receive_max:too_big",
     "packet": {
       "sequence": "0",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import 'mocha'
 import { Connection } from '../src/connection'
 import { DataAndMoneyStream } from '../src/stream'
-import { createConnection, Server, createServer } from '../src/index'
+import { createConnection, Server, createServer, GenerateAddressSecretOpts } from '../src/index'
 import MockPlugin from './mocks/plugin'
 import * as sinon from 'sinon'
 import * as Chai from 'chai'
@@ -65,7 +65,21 @@ describe('Server', function () {
       assert.typeOf(result.destinationAccount, 'string')
     })
 
-    it('should accept connections created without connectionTags', async function () {
+    it('should return whether or not the connection will have receipts', async function () {
+      await this.server.listen()
+
+      let result = this.server.generateAddressAndSecret()
+      assert.typeOf(result.receiptsEnabled, 'boolean')
+      assert.equal(result.receiptsEnabled, false)
+
+      const receiptNonce = Buffer.alloc(16)
+      const receiptSecret = Buffer.alloc(32)
+      result = this.server.generateAddressAndSecret({ receiptNonce, receiptSecret })
+      assert.typeOf(result.receiptsEnabled, 'boolean')
+      assert.equal(result.receiptsEnabled, true)
+    })
+
+    it('should accept connections created without options', async function () {
       await this.server.listen()
       const { destinationAccount, sharedSecret } = this.server.generateAddressAndSecret()
       const connectionPromise = this.server.acceptConnection()
@@ -79,10 +93,41 @@ describe('Server', function () {
       const connection = await connectionPromise
     })
 
-    it('should accept a connectionTag and attach it to the incoming connection', async function () {
+    it('should accept connections created with empty options', async function () {
+      await this.server.listen()
+      const opts: GenerateAddressSecretOpts = {}
+      const { destinationAccount, sharedSecret } = this.server.generateAddressAndSecret(opts)
+      const connectionPromise = this.server.acceptConnection()
+
+      const clientConn = await createConnection({
+        plugin: this.clientPlugin,
+        destinationAccount,
+        sharedSecret
+      })
+
+      const connection = await connectionPromise
+    })
+
+    it('should accept a connectionTag as a string and attach it to the incoming connection', async function () {
       await this.server.listen()
       const connectionTag = 'hello-there_123'
       const { destinationAccount, sharedSecret } = this.server.generateAddressAndSecret(connectionTag)
+      const connectionPromise = this.server.acceptConnection()
+
+      const clientConn = await createConnection({
+        plugin: this.clientPlugin,
+        destinationAccount,
+        sharedSecret
+      })
+
+      const connection = await connectionPromise
+      assert.equal(connection.connectionTag, connectionTag)
+    })
+
+    it('should accept a connectionTag and attach it to the incoming connection', async function () {
+      await this.server.listen()
+      const connectionTag = 'hello-there_123'
+      const { destinationAccount, sharedSecret } = this.server.generateAddressAndSecret({ connectionTag })
       const connectionPromise = this.server.acceptConnection()
 
       const clientConn = await createConnection({
@@ -120,9 +165,38 @@ describe('Server', function () {
       assert.notCalled(spy)
     })
 
-    it('should throw an error if the connectionTag includes characters that cannot go into an ILP address', async function () {
+    it('should accept receipt nonce and secret with or without connectionTag', async function () {
       await this.server.listen()
-      assert.throws(() => this.server.generateAddressAndSecret('invalid\n'), 'connectionTag can only include ASCII characters a-z, A-Z, 0-9, "_", "-", and "~"')
+      const connectionTag = 'hello-there_123'
+      const receiptNonce = Buffer.alloc(16)
+      const receiptSecret = Buffer.alloc(32)
+      this.server.generateAddressAndSecret({ connectionTag, receiptNonce, receiptSecret })
+      this.server.generateAddressAndSecret({ receiptNonce, receiptSecret })
+    })
+
+    it('should require receipt nonce and secret together', async function () {
+      await this.server.listen()
+      const connectionTag = 'hello-there_123'
+      const receiptNonce = Buffer.from('nonce_123', 'ascii')
+      const receiptSecret = Buffer.from('secret_123', 'ascii')
+      assert.throws(() => this.server.generateAddressAndSecret({ receiptNonce }), 'receiptNonce and receiptSecret must accompany each other')
+      assert.throws(() => this.server.generateAddressAndSecret({ receiptSecret }), 'receiptNonce and receiptSecret must accompany each other')
+      assert.throws(() => this.server.generateAddressAndSecret({ connectionTag, receiptNonce }), 'receiptNonce and receiptSecret must accompany each other')
+      assert.throws(() => this.server.generateAddressAndSecret({ connectionTag, receiptSecret }), 'receiptNonce and receiptSecret must accompany each other')
+    })
+
+    it('should require 16 byte receipt nonce', async function () {
+      await this.server.listen()
+      const receiptNonce = Buffer.alloc(15)
+      const receiptSecret = Buffer.alloc(32)
+      assert.throws(() => this.server.generateAddressAndSecret({ receiptNonce, receiptSecret }), 'receiptNonce must be 16 bytes')
+    })
+
+    it('should require 32 byte receipt secret', async function () {
+      await this.server.listen()
+      const receiptNonce = Buffer.alloc(16)
+      const receiptSecret = Buffer.alloc(31)
+      assert.throws(() => this.server.generateAddressAndSecret({ receiptNonce, receiptSecret }), 'receiptSecret must be 32 bytes')
     })
   })
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,4 +2,5 @@
 --ui mocha-typescript
 --require source-map-support/register
 --require ts-node/register
-test/**.test.ts
+test/*.test.ts
+test/util/*.test.ts

--- a/test/packet.test.ts
+++ b/test/packet.test.ts
@@ -139,12 +139,13 @@ describe('Packet Fixtures', function () {
 function buildFrame (options: any) {
   for (const key in options) {
     const value = options[key]
-    if (typeof value === 'string' && /^\d+$/.test(value)) {
-      options[key] = Long.fromString(value, true)
+    if (typeof value === 'string') {
+      if (/^\d+$/.test(value)) {
+        options[key] = Long.fromString(value, true)
+      } else if (['data', 'receipt'].indexOf(key) !== -1) {
+        options[key] = Buffer.from(value, 'base64')
+      }
     }
-  }
-  if (typeof options.data === 'string') {
-    options.data = Buffer.from(options.data, 'base64')
   }
   return Object.assign(
     Object.create(PacketModule[options.name + 'Frame'].prototype),

--- a/test/util/receipt.test.ts
+++ b/test/util/receipt.test.ts
@@ -1,0 +1,80 @@
+import 'mocha'
+import {
+  createReceipt,
+  decodeReceipt,
+  verifyReceipt,
+  RECEIPT_VERSION
+} from '../../src/util/receipt'
+import * as sinon from 'sinon'
+import * as Chai from 'chai'
+import { Writer } from 'oer-utils'
+import * as chaiAsPromised from 'chai-as-promised'
+import * as Long from 'long'
+import { longFromValue } from '../../src/util/long'
+import { randomBytes } from '../../src/crypto'
+Chai.use(chaiAsPromised)
+const assert = Object.assign(Chai.assert, sinon.assert)
+
+describe('Receipt', function () {
+  const receiptFixture = require('../fixtures/packets.json').find(({ name }: { name: string}) => name === 'frame:stream_receipt' ).packet.frames[0].receipt
+
+  describe('createReceipt', function () {
+    it('should create a receipt', function () {
+      const receipt = createReceipt({
+        nonce: Buffer.alloc(16),
+        streamId: '1',
+        totalReceived: '500',
+        secret: Buffer.alloc(32)
+      })
+      assert(receipt.equals(receiptFixture))
+    })
+    it('should require 16 byte nonce', function () {
+      assert.throws(() => createReceipt({
+        nonce: Buffer.alloc(8),
+        streamId: 'id',
+        totalReceived: '1',
+        secret: Buffer.alloc(32)
+      }), 'receipt nonce must be 16 bytes')
+    })
+    it('should require 32 byte secret', function () {
+      assert.throws(() => createReceipt({
+        nonce: Buffer.alloc(16),
+        streamId: 'id',
+        totalReceived: '1',
+        secret: Buffer.alloc(31)
+      }), 'receipt secret must be 32 bytes')
+    })
+  })
+
+  describe('decodeReceipt', function () {
+    it('should decode receipt', function () {
+      const receipt = decodeReceipt(receiptFixture)
+      assert.strictEqual(receipt.version, RECEIPT_VERSION)
+      assert(receipt.nonce.equals(Buffer.alloc(16)))
+      assert.strictEqual(receipt.streamId, '1')
+      assert(receipt.totalReceived.equals(500))
+    })
+    it('should require 58 byte receipt', function () {
+      assert.throws(() => decodeReceipt(Buffer.alloc(32)), 'receipt must be 58 bytes')
+    })
+  })
+
+  describe('verifyReceipt', function () {
+    it('should return true for valid receipt', function () {
+      const secret = Buffer.alloc(32)
+      assert.strictEqual(verifyReceipt(receiptFixture, secret), true)
+    })
+    it('should return false for invalid receipt length', function () {
+      const secret = Buffer.alloc(32)
+      assert.strictEqual(verifyReceipt(Buffer.alloc(57), secret), false)
+    })
+    it('should return false for invalid receipt version', function () {
+      const secret = Buffer.alloc(32)
+      assert.strictEqual(verifyReceipt(Buffer.alloc(58), secret), false)
+    })
+    it('should return false for invalid receipt hmac', function () {
+      const secret = randomBytes(32)
+      assert.strictEqual(verifyReceipt(receiptFixture, secret), false)
+    })
+  })
+})

--- a/test/util/receipt.test.ts
+++ b/test/util/receipt.test.ts
@@ -55,26 +55,30 @@ describe('Receipt', function () {
       assert(receipt.totalReceived.equals(500))
     })
     it('should require 58 byte receipt', function () {
-      assert.throws(() => decodeReceipt(Buffer.alloc(32)), 'receipt must be 58 bytes')
+      assert.throws(() => decodeReceipt(Buffer.alloc(32)), 'receipt malformed')
     })
   })
 
   describe('verifyReceipt', function () {
     it('should return true for valid receipt', function () {
       const secret = Buffer.alloc(32)
-      assert.strictEqual(verifyReceipt(receiptFixture, secret), true)
+      const receipt = verifyReceipt(receiptFixture, secret)
+      assert.strictEqual(receipt.version, RECEIPT_VERSION)
+      assert(receipt.nonce.equals(Buffer.alloc(16)))
+      assert.strictEqual(receipt.streamId, '1')
+      assert(receipt.totalReceived.equals(500))
     })
-    it('should return false for invalid receipt length', function () {
+    it('should throw for invalid receipt length', function () {
       const secret = Buffer.alloc(32)
-      assert.strictEqual(verifyReceipt(Buffer.alloc(57), secret), false)
+      assert.throws(() => verifyReceipt(Buffer.alloc(57), secret), 'receipt malformed')
     })
-    it('should return false for invalid receipt version', function () {
+    it('should throw for invalid receipt version', function () {
       const secret = Buffer.alloc(32)
-      assert.strictEqual(verifyReceipt(Buffer.alloc(58), secret), false)
+      assert.throws(() => verifyReceipt(Buffer.alloc(58), secret), 'invalid version')
     })
-    it('should return false for invalid receipt hmac', function () {
+    it('should throw for invalid receipt hmac', function () {
       const secret = randomBytes(32)
-      assert.strictEqual(verifyReceipt(receiptFixture, secret), false)
+      assert.throws(() => verifyReceipt(receiptFixture, secret), 'invalid hmac')
     })
   })
 })


### PR DESCRIPTION
https://github.com/interledger/rfcs/issues/568

Depends on https://github.com/interledger/rfcs/pull/570

Implementation details include:
- the server encodes the receipt nonce and secret (from SPSP queries) and appends them together as an additional segment after the token/connection tag in the destination address
- the latest receipt is exposed to the sender on the stream object allowing them to get it with every `outgoing_money` event and/or after calling `sendTotal`