### PR TITLE
feat: attach rejection to error

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1500,7 +1500,10 @@ export class Connection extends EventEmitter {
       await new Promise((resolve, reject) => setTimeout(resolve, delay))
     } else {
       this.log.error('unexpected error. code: %s, triggered by: %s, message: %s, data: %h', reject.code, reject.triggeredBy, reject.message, reject.data)
-      throw new Error(`Unexpected error while sending packet. Code: ${reject.code}, triggered by: ${reject.triggeredBy}, message: ${reject.message}`)
+      // This error will terminate the connection and bubble out to the caller.
+      const error = new Error(`Unexpected error while sending packet. Code: ${reject.code}, triggered by: ${reject.triggeredBy}, message: ${reject.message}`)
+      error['ilpReject'] = reject
+      throw error
     }
   }
 

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1200,6 +1200,7 @@ describe('Connection', function () {
       assert.equal(spy1.args[0][0].message, 'Total received exceeded MaxUint64')
       assert.calledOnce(spy2)
       assert.equal(spy2.args[0][0].message, 'Unexpected error while sending packet. Code: F00, triggered by: test.peerA, message: Total received exceeded MaxUint64')
+      assert.equal(spy2.args[0][0].ilpReject.code, 'F00')
     })
 
     it('supports a fixed maximumPacketAmount', async function () {


### PR DESCRIPTION
It can be useful to have access to the ILP rejection instead of just string a description of it.