### PR TITLE
feat: update documentation them to typedoc-neo-theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6949,6 +6949,107 @@
         "underscore": "^1.9.1"
       }
     },
+    "typedoc-neo-theme": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typedoc-neo-theme/-/typedoc-neo-theme-1.0.7.tgz",
+      "integrity": "sha512-MGwG/1uYgcMcFLffEPB683x4yWNbYwx/qG19c9NhMCOkbEmi1s7A/D1q7nXN00AY9NKaLl9wmc95XqX+uzgi8Q==",
+      "dev": true,
+      "requires": {
+        "typedoc": "0.16.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.7.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+          "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+          "dev": true,
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        },
+        "highlight.js": {
+          "version": "9.18.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+          "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "lunr": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+          "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+          "dev": true
+        },
+        "marked": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+          "dev": true
+        },
+        "typedoc": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.16.0.tgz",
+          "integrity": "sha512-arCzLnU4ijsSMPZvjcDhEQc4ROYueiCSZLCZL0uCZGtx8RDEC2H7ZNPiqR0Gd7UAgCByHJfn3MBFSkmrzrnVcA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "3.0.3",
+            "fs-extra": "^8.1.0",
+            "handlebars": "^4.7.0",
+            "highlight.js": "^9.17.1",
+            "lodash": "^4.17.15",
+            "marked": "^0.8.0",
+            "minimatch": "^3.0.0",
+            "progress": "^2.0.3",
+            "shelljs": "^0.8.3",
+            "typedoc-default-themes": "^0.7.0",
+            "typescript": "3.7.x"
+          }
+        },
+        "typedoc-default-themes": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz",
+          "integrity": "sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==",
+          "dev": true,
+          "requires": {
+            "backbone": "^1.4.0",
+            "jquery": "^3.4.1",
+            "lunr": "^2.3.8",
+            "underscore": "^1.9.1"
+          }
+        },
+        "typescript": {
+          "version": "3.7.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+          "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+          "dev": true
+        }
+      }
+    },
     "typescript": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "tslint --project .",
     "test": "TS_NODE_PROJECT='./tsconfig.test.json' mocha",
     "test-cover": "TS_NODE_PROJECT='./tsconfig.test.json' nyc --extension .ts mocha",
-    "doc": "typedoc --options typedoc.js src/index.ts src/connection.ts src/stream.ts",
+    "doc": "typedoc --options typedoc.js src/index.ts src/connection.ts src/stream.ts --theme node_modules/typedoc-neo-theme/bin/default",
     "publish-docs": "npm run doc && node scripts/publish-docs.js",
     "codecov": "codecov"
   },
@@ -79,6 +79,7 @@
     "tslint": "^5.10.0",
     "tslint-config-standard": "^8.0.0",
     "typedoc": "^0.15.0",
+    "typedoc-neo-theme": "^1.0.7",
     "typescript": "^3.6.0",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.7"


### PR DESCRIPTION
Updates documentation to use https://github.com/google/typedoc-neo-theme which are a little more readable. 

You can look at https://interledgerjs.github.io/ilp-protocol-stream/classes/_stream_.dataandmoneystream.html

Compared to
![Screen Shot 2020-03-27 at 4 09 19 PM](https://user-images.githubusercontent.com/4206970/77807693-d661a800-7045-11ea-9af3-cc8832bc1fa0.png)
