### PR TITLE
feat: accept secret generator for verifyReceipt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules
 coverage
 .nyc_output
 doc
+.idea
+yarn.lock

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   verifyReceipt,
   Receipt,
   ReceiptOpts,
+  ReceiptWithHMAC,
   RECEIPT_VERSION
 } from './util/receipt'
 

--- a/src/util/receipt.ts
+++ b/src/util/receipt.ts
@@ -19,7 +19,7 @@ export interface Receipt {
   totalReceived: Long
 }
 
-interface ReceiptWithHMAC extends Receipt {
+export interface ReceiptWithHMAC extends Receipt {
   hmac: Buffer
 }
 

--- a/src/util/receipt.ts
+++ b/src/util/receipt.ts
@@ -1,8 +1,5 @@
 import { Reader, Writer } from 'oer-utils'
-import {
-  LongValue,
-  longFromValue
-} from './long'
+import { longFromValue, LongValue } from './long'
 import * as Long from 'long'
 import { generateReceiptHMAC } from '../crypto'
 
@@ -65,10 +62,13 @@ export function decodeReceipt (receipt: Buffer): Receipt {
   return decode(receipt)
 }
 
-export function verifyReceipt (receipt: Buffer, secret: Buffer): Receipt {
+export function verifyReceipt (receipt: Buffer, secret: Buffer | ((decoded: ReceiptWithHMAC) => Buffer)): Receipt {
   const decoded = decode(receipt)
   if (decoded.version !== RECEIPT_VERSION) {
     throw new Error('invalid version')
+  }
+  if (typeof secret === 'function') {
+    secret = secret(decoded)
   }
   const message = receipt.slice(0, 26)
   if (!decoded.hmac.equals(generateReceiptHMAC(secret, message))) {

--- a/test/util/receipt.test.ts
+++ b/test/util/receipt.test.ts
@@ -60,6 +60,13 @@ describe('Receipt', function () {
   })
 
   describe('verifyReceipt', function () {
+    it('should be able to take a function as secret ', function () {
+      verifyReceipt(receiptFixture, (decoded) => {
+        // we may want to compute the secret based on the decoded nonce
+        assert.isDefined(decoded.nonce)
+        return Buffer.alloc(32)
+      })
+    })
     it('should return true for valid receipt', function () {
       const secret = Buffer.alloc(32)
       const receipt = verifyReceipt(receiptFixture, secret)


### PR DESCRIPTION
re: https://github.com/interledgerjs/ilp-protocol-stream/issues/144