### PR TITLE
Minor fixes for send-only clients

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -966,6 +966,7 @@ export class Connection extends EventEmitter {
     }
     if (!this._destinationAccount) {
       this.log.debug('not sending because we do not know the client\'s address')
+      this.safeEmit('_send_loop_finished')
       return
     }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -671,6 +671,13 @@ export class Connection extends EventEmitter {
       })
     }
 
+    // Add incoming amounts to each stream
+    const totalsReceived: Map<number, string> = new Map()
+    for (let { stream, amount } of amountsToReceive) {
+      stream._addToIncoming(amount, prepare)
+      totalsReceived.set(stream.id, stream.totalReceived)
+    }
+
     // Tell peer about closed streams and how much each stream can receive
     if (!this.closed && this.remoteState !== RemoteState.Closed) {
       for (let [_, stream] of this.streams) {
@@ -691,13 +698,6 @@ export class Connection extends EventEmitter {
           responseFrames.push(new StreamMaxDataFrame(stream.id, stream._getIncomingOffsets().maxAcceptable))
         }
       }
-    }
-
-    // Add incoming amounts to each stream
-    const totalsReceived: Map<number, string> = new Map()
-    for (let { stream, amount } of amountsToReceive) {
-      stream._addToIncoming(amount, prepare)
-      totalsReceived.set(stream.id, stream.totalReceived)
     }
 
     // Add receipt frame(s)

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -133,6 +133,11 @@ describe('Connection', function () {
       assert.calledOnce(closeSpy)
     })
 
+    it('should resolve even if the remote address is unknown', async function () {
+      delete this.serverConn._destinationAccount
+      await this.serverConn.end()
+    })
+
     it('should close all outgoing streams', async function () {
       const clientSpy = {
         stream1: {


### PR DESCRIPTION
- Fix server hanging on shutdown if client never shared their ILP address
- Share asset details in response to every `ConnectionNewAddress` frame
- Fix bug in `totalReceived` accounting in `StreamMaxMoney` frames