### PR TITLE
fix: tidy up after the determineExchangeRate loop

### DIFF
--- a/src/util/stoppable-timeout.ts
+++ b/src/util/stoppable-timeout.ts
@@ -1,0 +1,27 @@
+// When `stop` is been called:
+// - The current `wait` promise (if any) will reject.
+// - All future `wait` calls with reject.
+export class StoppableTimeout {
+  private stopped: boolean = false
+  private timer: NodeJS.Timer
+  private reject?: (err: Error) => void
+
+  wait (delay: number): Promise<void> {
+    if (this.stopped) {
+      return Promise.reject(new Error('timer stopped'))
+    }
+
+    return new Promise((resolve, reject) => {
+      this.timer = setTimeout(resolve, delay)
+      this.reject = reject
+    })
+  }
+
+  stop (): void {
+    clearTimeout(this.timer)
+    this.stopped = true
+    if (this.reject) {
+      this.reject(new Error('timer stopped'))
+    }
+  }
+}


### PR DESCRIPTION
# Problem

In the following scenario:

- Client connects to server.
- Client negotiates exchange rate with server.
- Server tries to negotiate an exchange rate with the client. But it doesn't work due to `Txx` errors.
- The client sends money, then closes the connection.
- The server closes the connection.

... but `determineExchangeRate()` keeps going. Because of the backoff settings and many attempts, it will continue for ~7.4 minutes. Eventually it runs out of attempts and throws the `Unable to establish connection, no packets meeting …` error, which is emitted by the `Connection`.

# Solution

When the connection ends, if a `determineExchangeRate` is running, abort it immediately.

Also, when `determineExchangeRate` throws, `startSendLoop` tries to `destroy` the `Connection`. Previously, this would emit an error (even though the connection is already terminated). This would just be logged, but it's misleading and annoying. Now the connection will ignore `destroy()` calls after it is all done (either via `end` or `destroy`).