### PR TITLE
perf(server): clean up closed connections

### DIFF
--- a/src/util/aging-set.ts
+++ b/src/util/aging-set.ts
@@ -1,0 +1,32 @@
+export class AgingSet {
+  private newSet: Set<string> = new Set()
+  private oldSet: Set<string> = new Set()
+  private timer: NodeJS.Timer
+
+  /**
+   * `cycleInterval` specifies the frequency that the sets are swapped.
+   */
+  constructor (cycleInterval: number) {
+    this.timer = setInterval(this.rotate.bind(this), cycleInterval)
+  }
+
+  close () {
+    clearInterval(this.timer)
+  }
+
+  has (element: string): boolean {
+    return this.newSet.has(element) || this.oldSet.has(element)
+  }
+
+  add (element: string) {
+    this.newSet.add(element)
+  }
+
+  private rotate () {
+    const newSet = this.newSet
+    const oldSet = this.oldSet
+    this.oldSet = newSet
+    this.newSet = oldSet
+    this.newSet.clear()
+  }
+}

--- a/test/util/aging-set.test.ts
+++ b/test/util/aging-set.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { AgingSet } from '../../src/util/aging-set'
+
+describe('AgingSet', function () {
+  beforeEach(function () {
+    this.clock = sinon.useFakeTimers({
+      toFake: ['setInterval']
+    })
+    this.set = new AgingSet(1000)
+  })
+
+  afterEach(function () {
+    this.clock.restore()
+  })
+
+  it('includes newly added elements', function () {
+    this.set.add("foo")
+    assert(this.set.has("foo"))
+  })
+
+  it('doesn\'t include random elements', function () {
+    assert(!this.set.has("foo"))
+  })
+
+  it('includes once-rotated elements', function () {
+    this.set.add("foo")
+    this.clock.tick(1001)
+    assert(this.set.has("foo"))
+  })
+
+  it('doesn\'t include twice-rotated elements', function () {
+    this.set.add("foo")
+    this.clock.tick(2001)
+    assert(!this.set.has("foo"))
+  })
+})


### PR DESCRIPTION
To avoid leaking memory, don't store the connection Ids of closed connections indefinitely. Storing them for 20 minutes should be plenty.