### PR TITLE
fix uncaught rejection

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1369,14 +1369,17 @@ export class Connection extends EventEmitter {
     }
 
     /* tslint:disable-next-line:no-unnecessary-type-assertion */
-    const responseData = await (new Promise(async (resolve, reject) => {
+    const responseData = await (new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.log.error('test packet %s timed out before we got a response', requestPacket.sequence)
         resolve(null)
       }, timeout)
-      const result = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(prepare))
-      clearTimeout(timer)
-      resolve(result)
+      this.plugin.sendData(IlpPacket.serializeIlpPrepare(prepare))
+        .then((result) => {
+          clearTimeout(timer)
+          resolve(result)
+        })
+        .catch(reject)
     }) as Promise<Buffer | null>)
 
     if (!responseData) {


### PR DESCRIPTION
Fixes a bug that Uphold ran into. An uncaught rejection was bubbling up from `end()`.

I was unable to reproduce locally or as a test case. My best guess is that the error is triggered by a concurrent `startSendLoop` (i.e. the exchange rate probe) that triggers an error event, while simultaneously a `ConnectionClose` frame is being handled. The `error` is caught by the `.once('error', reject)` in the `end` method, which bubbles it up.

Also includes a fix for an unrelated `sendData` error.